### PR TITLE
Add Node.js ExtStressSolver demos for projectile and bridge scenarios

### DIFF
--- a/blast/js_stress_example/README.md
+++ b/blast/js_stress_example/README.md
@@ -22,3 +22,50 @@ The build step compiles `stress_bridge.cpp` together with the Blast stress solve
 implementation (`stress.cpp`) to `dist/stress_solver.{cjs,wasm}`. The demo script
 then loads the generated module, feeds the same frame inputs as the Rust example,
 computes bond stresses, and logs which bonds fail under the configured limits.
+
+To exercise the high-level `ExtStressSolver` wrapper from Node.js, run the
+dedicated example:
+
+```bash
+cd blast/js_stress_example
+npm run demo:ext
+```
+
+This script applies gravity and a downward impulse on the top node, steps the
+solver until it converges, and prints debug-render line samples generated via
+`fillDebugRender`.
+
+## ExtStressSolver bindings
+
+The build also bundles the Blast `ExtStressSolver` extension.  You can create and
+drive the high-level solver from JavaScript by calling
+`runtime.createExtSolver({ nodes, bonds, settings })`.  Each node entry should
+include a centroid, mass, and volume, while each bond entry describes the
+centroid, surface normal, area, and the connected node indices.  Once created,
+the solver exposes helpers for applying forces or gravity, advancing the solver,
+querying overstressed bonds, and fetching `fillDebugRender` output for visual
+debugging.
+
+```js
+const runtime = await loadStressSolver();
+const solver = runtime.createExtSolver({
+  nodes: [
+    { centroid: vec3(-1, 0, 0), mass: 25, volume: 2.5 },
+    { centroid: vec3(1, 0, 0), mass: 25, volume: 2.5 },
+    { centroid: vec3(0, 1.5, 0), mass: 15, volume: 1.5 }
+  ],
+  bonds: [
+    { centroid: vec3(-0.5, 0.75, 0), normal: vec3(-0.6, 0.8, 0), area: 0.6, node0: 0, node1: 2 },
+    { centroid: vec3(0.5, 0.75, 0), normal: vec3(0.6, 0.8, 0), area: 0.6, node0: 1, node1: 2 }
+  ],
+  settings: runtime.defaultExtSettings()
+});
+
+solver.addForce(2, vec3(), vec3(0, -50, 0));
+solver.update();
+const debugLines = solver.fillDebugRender({ mode: runtime.ExtDebugMode.Max });
+solver.destroy();
+```
+
+All helper enums (`ExtForceMode`, `ExtDebugMode`) and default settings are
+exposed on the runtime object returned by `loadStressSolver`.

--- a/blast/js_stress_example/README.md
+++ b/blast/js_stress_example/README.md
@@ -35,6 +35,25 @@ This script applies gravity and a downward impulse on the top node, steps the
 solver until it converges, and prints debug-render line samples generated via
 `fillDebugRender`.
 
+Additional `ExtStressSolver` demos are available:
+
+```bash
+cd blast/js_stress_example
+npm run demo:ext-cube      # Projectile vs. fractured cube
+npm run demo:ext-bridge    # Heavy vehicles collapsing a bridge deck
+```
+
+- `ext-cube-projectile.js` procedurally fractures a cube into eight pieces,
+  applies gravity plus a high-speed projectile impulse, and reports the bonds
+  predicted to fail along the impacted face. Debug-render lines are sorted by
+  magnitude so that the most stressed bonds are easy to inspect.
+- `ext-bridge-cars.js` builds a beam bridge with layered deck fragments and
+  suspension piers. It sweeps a heavy "car" load across successive deck
+  segments, printing per-span solver errors, overstressed bond counts, and the
+  hottest debug lines. Once the car load creates an overstressed bond the demo
+  flags the deck as failed, mirroring how a game would generate fracture
+  commands from the solver output.
+
 ## ExtStressSolver bindings
 
 The build also bundles the Blast `ExtStressSolver` extension.  You can create and

--- a/blast/js_stress_example/ext-bridge-cars.js
+++ b/blast/js_stress_example/ext-bridge-cars.js
@@ -1,0 +1,241 @@
+import { loadStressSolver, vec3, formatNumber } from './stress.js';
+
+function buildBridgeScenario({
+  span = 12.0,
+  deckWidth = 4.0,
+  deckThickness = 0.6,
+  spanSegments = 6,
+  widthSegments = 2,
+  thicknessLayers = 2,
+  deckMass = 6000.0,
+  pierHeight = 3.0
+} = {}) {
+  const nodes = [];
+  const bonds = [];
+
+  const spacingX = span / (spanSegments - 1);
+  const spacingZ = widthSegments > 1 ? deckWidth / (widthSegments - 1) : deckWidth;
+  const spacingY = thicknessLayers > 1 ? deckThickness / (thicknessLayers - 1) : deckThickness;
+
+  const originX = -span / 2;
+  const originZ = widthSegments > 1 ? -deckWidth / 2 : 0.0;
+  const originY = -deckThickness / 2;
+
+  const totalDeckNodes = spanSegments * widthSegments * thicknessLayers;
+  const massPerDeckNode = deckMass / totalDeckNodes;
+  const volumePerDeckNode = spacingX * spacingZ * spacingY;
+
+  const nodeIndex = Array.from({ length: spanSegments }, () =>
+    Array.from({ length: thicknessLayers }, () => Array(widthSegments))
+  );
+  const topColumnNodes = Array.from({ length: spanSegments }, () => []);
+  const deckBottomNodes = [];
+
+  const indexAt = (ix, iy, iz) => nodeIndex[ix][iy][iz];
+
+  for (let ix = 0; ix < spanSegments; ++ix) {
+    for (let iy = 0; iy < thicknessLayers; ++iy) {
+      for (let iz = 0; iz < widthSegments; ++iz) {
+        const centroid = vec3(
+          originX + ix * spacingX,
+          originY + iy * spacingY,
+          originZ + iz * spacingZ
+        );
+        const node = { centroid, mass: massPerDeckNode, volume: volumePerDeckNode };
+        const index = nodes.length;
+        nodes.push(node);
+        nodeIndex[ix][iy][iz] = index;
+        if (iy === thicknessLayers - 1) {
+          topColumnNodes[ix].push(index);
+        }
+        if (iy === 0) {
+          deckBottomNodes.push(index);
+        }
+      }
+    }
+  }
+
+  const areaScale = 0.05;
+  const deckBondAreaX = spacingY * spacingZ * areaScale;
+  const deckBondAreaY = spacingX * spacingZ * areaScale;
+  const deckBondAreaZ = spacingX * spacingY * areaScale;
+
+  const addBond = (a, b, area) => {
+    const na = nodes[a];
+    const nb = nodes[b];
+    const centroid = vec3(
+      (na.centroid.x + nb.centroid.x) / 2,
+      (na.centroid.y + nb.centroid.y) / 2,
+      (na.centroid.z + nb.centroid.z) / 2
+    );
+    const normal = normalize(subtract(nb.centroid, na.centroid));
+    bonds.push({ centroid, normal, area, node0: a, node1: b });
+  };
+
+  for (let ix = 0; ix < spanSegments; ++ix) {
+    for (let iy = 0; iy < thicknessLayers; ++iy) {
+      for (let iz = 0; iz < widthSegments; ++iz) {
+        const current = indexAt(ix, iy, iz);
+        if (ix + 1 < spanSegments) {
+          addBond(current, indexAt(ix + 1, iy, iz), deckBondAreaX);
+        }
+        if (iy + 1 < thicknessLayers) {
+          addBond(current, indexAt(ix, iy + 1, iz), deckBondAreaY);
+        }
+        if (iz + 1 < widthSegments) {
+          addBond(current, indexAt(ix, iy, iz + 1), deckBondAreaZ);
+        }
+      }
+    }
+  }
+
+  const supportIndices = [];
+  const supportArea = spacingX * spacingZ * areaScale;
+  const supportMass = massPerDeckNode * 6.0;
+  const supportVolume = spacingX * spacingZ * pierHeight;
+
+  for (const ix of [0, spanSegments - 1]) {
+    for (let iz = 0; iz < widthSegments; ++iz) {
+      const baseIndex = indexAt(ix, 0, iz);
+      const baseNode = nodes[baseIndex];
+      const supportCentroid = vec3(baseNode.centroid.x, baseNode.centroid.y - pierHeight, baseNode.centroid.z);
+      const supportIndex = nodes.length;
+      nodes.push({ centroid: supportCentroid, mass: supportMass, volume: supportVolume });
+      supportIndices.push(supportIndex);
+      addBond(baseIndex, supportIndex, supportArea);
+    }
+  }
+
+  return {
+    nodes,
+    bonds,
+    topColumnNodes,
+    supportIndices,
+    spanSegments,
+    widthSegments
+  };
+}
+
+function subtract(a, b) {
+  return vec3(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+
+function normalize(v) {
+  const len = Math.hypot(v.x, v.y, v.z);
+  if (len === 0) {
+    return vec3();
+  }
+  return vec3(v.x / len, v.y / len, v.z / len);
+}
+
+function summarizeLines(lines, limit = 3) {
+  const sorted = [...lines].sort((a, b) => lineMagnitude(b) - lineMagnitude(a));
+  return sorted.slice(0, limit).map((line) => ({
+    length: lineMagnitude(line),
+    centerX: (line.p0.x + line.p1.x) / 2,
+    centerY: (line.p0.y + line.p1.y) / 2,
+    centerZ: (line.p0.z + line.p1.z) / 2,
+    color: `0x${line.color0.toString(16).padStart(8, '0')}`
+  }));
+}
+
+function lineMagnitude(line) {
+  const dx = line.p1.x - line.p0.x;
+  const dy = line.p1.y - line.p0.y;
+  const dz = line.p1.z - line.p0.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+async function main() {
+  const scenario = buildBridgeScenario();
+  console.log(`Bridge scenario created with ${scenario.nodes.length} nodes and ${scenario.bonds.length} bonds`);
+
+  const runtime = await loadStressSolver();
+  const settings = runtime.defaultExtSettings();
+  settings.compressionElasticLimit = 0.05;
+  settings.compressionFatalLimit = 0.1;
+  settings.tensionElasticLimit = 0.05;
+  settings.tensionFatalLimit = 0.1;
+  settings.shearElasticLimit = 0.05;
+  settings.shearFatalLimit = 0.1;
+
+  const solver = runtime.createExtSolver({
+    nodes: scenario.nodes,
+    bonds: scenario.bonds,
+    settings
+  });
+
+  const gravity = vec3(0.0, -6.0, 0.0);
+  const carMass = 5200.0;
+  const impactMultiplier = 3.5;
+
+  const segments = scenario.spanSegments;
+  const contactsPerStep = [];
+  for (let column = 0; column < segments - 1; ++column) {
+    const contact = [...scenario.topColumnNodes[column], ...scenario.topColumnNodes[column + 1]];
+    contactsPerStep.push(contact);
+  }
+
+  let failureDetected = false;
+  for (let index = 0; index < contactsPerStep.length; ++index) {
+    const contact = contactsPerStep[index];
+    solver.reset();
+    solver.addGravity(gravity);
+
+    const baseForcePerNode = (carMass * 9.81) / contact.length;
+    const severity = 1.0 + index * 1.4;
+    contact.forEach((nodeIndex, contactIdx) => {
+      const dynamicBoost = contactIdx < contact.length / 2 ? 1.0 : impactMultiplier;
+      const downwardForce = baseForcePerNode * severity * dynamicBoost;
+      solver.addForce(nodeIndex, vec3(), vec3(0.0, -downwardForce, 0.0));
+    });
+
+    let step = 0;
+    while (!solver.converged() && step < 30) {
+      solver.update();
+      const error = solver.stressError();
+      console.log(
+        `span step ${String(index + 1).padStart(2)}.${String(step + 1).padStart(2)} | lin ${formatNumber(
+          error.lin,
+          7,
+          4
+        )} | ang ${formatNumber(error.ang, 7, 4)}`
+      );
+      step += 1;
+    }
+
+    const overstressed = solver.overstressedBondCount();
+    console.log(
+      `  contact group ${String(index + 1).padStart(2)} on columns ${index}-${index + 1} produced ${overstressed} overstressed bonds`
+    );
+
+    const debugLines = solver.fillDebugRender({ mode: runtime.ExtDebugMode.Max, scale: 1.0 });
+    const highlights = summarizeLines(debugLines, 4);
+    highlights.forEach((line, highlightIndex) => {
+      console.log(
+        `    debug line ${highlightIndex} | length ${formatNumber(line.length, 6, 3)} | center (${formatNumber(
+          line.centerX,
+          6,
+          2
+        )}, ${formatNumber(line.centerY, 6, 2)}, ${formatNumber(line.centerZ, 6, 2)}) | color ${line.color}`
+      );
+    });
+
+    if (overstressed > 0) {
+      console.log('  -> Bridge deck predicted to fail under this car position. Stopping simulation.');
+      failureDetected = true;
+      break;
+    }
+  }
+
+  if (!failureDetected) {
+    console.log('Bridge deck survived the scripted car sweep without exceeding the configured stress limits.');
+  }
+
+  solver.destroy();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/blast/js_stress_example/ext-cube-projectile.js
+++ b/blast/js_stress_example/ext-cube-projectile.js
@@ -1,0 +1,167 @@
+import {
+  loadStressSolver,
+  vec3,
+  formatVec3,
+  formatNumber
+} from './stress.js';
+
+function buildCubeScenario({
+  cubeSize = 2.0,
+  cellsPerAxis = 2,
+  totalMass = 160.0
+} = {}) {
+  const cellSize = cubeSize / cellsPerAxis;
+  const start = -cubeSize / 2 + cellSize / 2;
+  const coords = Array.from({ length: cellsPerAxis }, (_, i) => start + i * cellSize);
+  const nodes = [];
+  const indexOf = new Map();
+  const volume = cellSize * cellSize * cellSize;
+  const massPerNode = totalMass / (cellsPerAxis ** 3);
+
+  const key = (ix, iy, iz) => `${ix},${iy},${iz}`;
+  const idx = (ix, iy, iz) => indexOf.get(key(ix, iy, iz));
+
+  coords.forEach((x, ix) => {
+    coords.forEach((y, iy) => {
+      coords.forEach((z, iz) => {
+        const node = { centroid: vec3(x, y, z), mass: massPerNode, volume };
+        const index = nodes.length;
+        nodes.push(node);
+        indexOf.set(key(ix, iy, iz), index);
+      });
+    });
+  });
+
+  const bonds = [];
+  const frontFaceNodes = [];
+  const area = cellSize * cellSize;
+
+  const addBond = (a, b) => {
+    const nodeA = nodes[a];
+    const nodeB = nodes[b];
+    const centroid = vec3(
+      (nodeA.centroid.x + nodeB.centroid.x) / 2,
+      (nodeA.centroid.y + nodeB.centroid.y) / 2,
+      (nodeA.centroid.z + nodeB.centroid.z) / 2
+    );
+    const normal = normalize(subtract(nodeB.centroid, nodeA.centroid));
+    bonds.push({ centroid, normal, area, node0: a, node1: b });
+  };
+
+  for (let ix = 0; ix < cellsPerAxis; ++ix) {
+    for (let iy = 0; iy < cellsPerAxis; ++iy) {
+      for (let iz = 0; iz < cellsPerAxis; ++iz) {
+        const current = idx(ix, iy, iz);
+        if (iz === cellsPerAxis - 1) {
+          frontFaceNodes.push(current);
+        }
+        if (ix + 1 < cellsPerAxis) {
+          addBond(current, idx(ix + 1, iy, iz));
+        }
+        if (iy + 1 < cellsPerAxis) {
+          addBond(current, idx(ix, iy + 1, iz));
+        }
+        if (iz + 1 < cellsPerAxis) {
+          addBond(current, idx(ix, iy, iz + 1));
+        }
+      }
+    }
+  }
+
+  return { nodes, bonds, frontFaceNodes, cellSize };
+}
+
+function subtract(a, b) {
+  return vec3(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+
+function length(v) {
+  return Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+}
+
+function normalize(v) {
+  const len = length(v);
+  if (len === 0) {
+    return vec3();
+  }
+  return vec3(v.x / len, v.y / len, v.z / len);
+}
+
+function logDebugLines(lines, limit = 5) {
+  const sorted = [...lines].sort((a, b) => lineLength(b) - lineLength(a));
+  sorted.slice(0, limit).forEach((line, index) => {
+    console.log(
+      `  line ${String(index).padStart(2)} | length ${formatNumber(lineLength(line), 6, 3)} | p0 ${formatVec3(line.p0)} | p1 ${formatVec3(line.p1)} | color0 0x${
+        line.color0.toString(16).padStart(8, '0')
+      }`
+    );
+  });
+}
+
+function lineLength(line) {
+  const dx = line.p1.x - line.p0.x;
+  const dy = line.p1.y - line.p0.y;
+  const dz = line.p1.z - line.p0.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+async function main() {
+  const scenario = buildCubeScenario({ cubeSize: 2.0, cellsPerAxis: 2, totalMass: 160.0 });
+  console.log(`Cube scenario created with ${scenario.nodes.length} nodes and ${scenario.bonds.length} bonds`);
+
+  const runtime = await loadStressSolver();
+  const settings = runtime.defaultExtSettings();
+  settings.compressionElasticLimit = 0.8;
+  settings.compressionFatalLimit = 1.3;
+  settings.tensionElasticLimit = 0.6;
+  settings.tensionFatalLimit = 1.1;
+  settings.shearElasticLimit = 0.6;
+  settings.shearFatalLimit = 1.0;
+
+  const solver = runtime.createExtSolver({
+    nodes: scenario.nodes,
+    bonds: scenario.bonds,
+    settings
+  });
+
+  solver.addGravity(vec3(0.0, -9.81, 0.0));
+
+  const projectileForce = 4200.0;
+  scenario.frontFaceNodes.forEach((index) => {
+    solver.addForce(index, vec3(), vec3(0.0, 0.0, -projectileForce));
+  });
+
+  let step = 0;
+  while (!solver.converged() && step < 32) {
+    solver.update();
+    const error = solver.stressError();
+    console.log(
+      `step ${String(step + 1).padStart(2)} | linear error ${formatNumber(error.lin, 8, 5)} | angular error ${formatNumber(
+        error.ang,
+        8,
+        5
+      )}`
+    );
+    step += 1;
+  }
+
+  const overstressed = solver.overstressedBondCount();
+  console.log(`\nProjectile impact produced ${overstressed} overstressed bonds`);
+
+  const debugLines = solver.fillDebugRender({ mode: runtime.ExtDebugMode.Max, scale: 1.0 });
+  console.log(`Debug render emitted ${debugLines.length} lines (showing top ${Math.min(5, debugLines.length)})`);
+  logDebugLines(debugLines);
+
+  console.log('\nFront face nodes:');
+  scenario.frontFaceNodes.forEach((nodeIndex) => {
+    const node = scenario.nodes[nodeIndex];
+    console.log(`  node ${nodeIndex} | centroid ${formatVec3(node.centroid)}`);
+  });
+
+  solver.destroy();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/blast/js_stress_example/ext-demo.js
+++ b/blast/js_stress_example/ext-demo.js
@@ -1,0 +1,77 @@
+import {
+  loadStressSolver,
+  vec3,
+  formatVec3,
+  formatNumber
+} from './stress.js';
+
+const NODE_LABELS = ['left', 'right', 'top'];
+
+const NODE_DESCRIPTIONS = [
+  { centroid: vec3(-1.0, 0.0, 0.0), mass: 25.0, volume: 2.5 },
+  { centroid: vec3(1.0, 0.0, 0.0), mass: 25.0, volume: 2.5 },
+  { centroid: vec3(0.0, 1.5, 0.0), mass: 15.0, volume: 1.5 }
+];
+
+const BOND_DESCRIPTIONS = [
+  {
+    name: 'left diagonal',
+    desc: { centroid: vec3(-0.5, 0.75, 0.0), normal: vec3(-0.6, 0.8, 0.0), area: 0.6, node0: 0, node1: 2 }
+  },
+  {
+    name: 'right diagonal',
+    desc: { centroid: vec3(0.5, 0.75, 0.0), normal: vec3(0.6, 0.8, 0.0), area: 0.6, node0: 1, node1: 2 }
+  },
+  {
+    name: 'base tie',
+    desc: { centroid: vec3(0.0, 0.0, 0.0), normal: vec3(0.0, 1.0, 0.0), area: 0.9, node0: 0, node1: 1 }
+  }
+];
+
+async function main() {
+  const runtime = await loadStressSolver();
+  const solver = runtime.createExtSolver({
+    nodes: NODE_DESCRIPTIONS,
+    bonds: BOND_DESCRIPTIONS.map((entry) => entry.desc),
+    settings: runtime.defaultExtSettings()
+  });
+
+  console.log(`ExtStressSolver created with ${solver.graphNodeCount()} graph nodes`);
+
+  solver.addGravity(vec3(0.0, -9.81, 0.0));
+  solver.addForce(2, vec3(), vec3(0.0, -200.0, 0.0));
+
+  let step = 0;
+  while (!solver.converged() && step < 10) {
+    solver.update();
+    const error = solver.stressError();
+    console.log(
+      `step ${String(step + 1).padStart(2)} | linear error ${formatNumber(error.lin, 8, 5)} | angular error ${formatNumber(
+        error.ang,
+        8,
+        5
+      )}`
+    );
+    step += 1;
+  }
+
+  console.log(`\nOverstressed bonds reported: ${solver.overstressedBondCount()}`);
+
+  const debugLines = solver.fillDebugRender({ mode: runtime.ExtDebugMode.Max, scale: 1.0 });
+  console.log(`Debug render lines: ${debugLines.length}`);
+  debugLines.slice(0, 3).forEach((line, index) => {
+    console.log(`  line ${index} | p0 ${formatVec3(line.p0)} | p1 ${formatVec3(line.p1)}`);
+  });
+
+  console.log('\nFinal node state:');
+  NODE_DESCRIPTIONS.forEach((node, index) => {
+    console.log(`  ${NODE_LABELS[index].padEnd(5)} | centroid ${formatVec3(node.centroid)} | mass ${node.mass.toFixed(1)}`);
+  });
+
+  solver.destroy();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/blast/js_stress_example/package.json
+++ b/blast/js_stress_example/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "build": "node ./scripts/build.js",
     "demo": "npm run build --silent && node ./demo.js",
-    "demo:ext": "npm run build --silent && node ./ext-demo.js"
+    "demo:ext": "npm run build --silent && node ./ext-demo.js",
+    "demo:ext-cube": "npm run build --silent && node ./ext-cube-projectile.js",
+    "demo:ext-bridge": "npm run build --silent && node ./ext-bridge-cars.js"
   }
 }

--- a/blast/js_stress_example/package.json
+++ b/blast/js_stress_example/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "node ./scripts/build.js",
-    "demo": "npm run build --silent && node ./demo.js"
+    "demo": "npm run build --silent && node ./demo.js",
+    "demo:ext": "npm run build --silent && node ./ext-demo.js"
   }
 }

--- a/blast/js_stress_example/scripts/build.js
+++ b/blast/js_stress_example/scripts/build.js
@@ -14,10 +14,18 @@ mkdirSync(distDir, { recursive: true });
 const ffiDir = resolve(blastRoot, 'rust_stress_example/ffi');
 const solverDir = resolve(blastRoot, 'source/shared/stress_solver');
 const sharedDir = resolve(blastRoot, 'source/shared');
+const sharedNsFoundationIncludeDir = resolve(sharedDir, 'NsFoundation', 'include');
 const includeDir = resolve(blastRoot, 'include');
 const includeGlobalsDir = resolve(includeDir, 'globals');
 const includeSharedDir = resolve(includeDir, 'shared');
+const includeLowLevelDir = resolve(includeDir, 'lowlevel');
+const includeExtensionsDir = resolve(includeDir, 'extensions');
+const includeStressExtDir = resolve(includeExtensionsDir, 'stress');
 const foundationDir = resolve(includeSharedDir, 'NvFoundation');
+const sdkCommonDir = resolve(blastRoot, 'source/sdk/common');
+const sdkGlobalsDir = resolve(blastRoot, 'source/sdk/globals');
+const sdkLowLevelDir = resolve(blastRoot, 'source/sdk/lowlevel');
+const sdkStressDir = resolve(blastRoot, 'source/sdk/extensions/stress');
 
 const exportedFunctions = [
   '_stress_processor_create',
@@ -37,6 +45,24 @@ const exportedFunctions = [
   '_stress_sizeof_data_params',
   '_stress_sizeof_solver_params',
   '_stress_sizeof_error_sq',
+  '_ext_stress_solver_create',
+  '_ext_stress_solver_destroy',
+  '_ext_stress_solver_set_settings',
+  '_ext_stress_solver_graph_node_count',
+  '_ext_stress_solver_bond_count',
+  '_ext_stress_solver_reset',
+  '_ext_stress_solver_add_force',
+  '_ext_stress_solver_add_gravity',
+  '_ext_stress_solver_update',
+  '_ext_stress_solver_overstressed_bond_count',
+  '_ext_stress_solver_fill_debug_render',
+  '_ext_stress_solver_get_linear_error',
+  '_ext_stress_solver_get_angular_error',
+  '_ext_stress_solver_converged',
+  '_ext_stress_sizeof_ext_node_desc',
+  '_ext_stress_sizeof_ext_bond_desc',
+  '_ext_stress_sizeof_ext_settings',
+  '_ext_stress_sizeof_ext_debug_line',
   '_malloc',
   '_free'
 ];
@@ -61,14 +87,36 @@ const exportedRuntimeMethods = [
 
 const commonArgs = [
   resolve(ffiDir, 'stress_bridge.cpp'),
+  resolve(ffiDir, 'ext_stress_bridge.cpp'),
   resolve(solverDir, 'stress.cpp'),
+  resolve(sdkStressDir, 'NvBlastExtStressSolver.cpp'),
+  resolve(sdkCommonDir, 'NvBlastAssert.cpp'),
+  resolve(sdkCommonDir, 'NvBlastAtomic.cpp'),
+  resolve(sdkCommonDir, 'NvBlastTime.cpp'),
+  resolve(sdkCommonDir, 'NvBlastTimers.cpp'),
+  resolve(sdkGlobalsDir, 'NvBlastGlobals.cpp'),
+  resolve(sdkGlobalsDir, 'NvBlastInternalProfiler.cpp'),
+  resolve(sdkLowLevelDir, 'NvBlastActor.cpp'),
+  resolve(sdkLowLevelDir, 'NvBlastActorSerializationBlock.cpp'),
+  resolve(sdkLowLevelDir, 'NvBlastAsset.cpp'),
+  resolve(sdkLowLevelDir, 'NvBlastAssetHelper.cpp'),
+  resolve(sdkLowLevelDir, 'NvBlastFamily.cpp'),
+  resolve(sdkLowLevelDir, 'NvBlastFamilyGraph.cpp'),
   '-I' + ffiDir,
   '-I' + solverDir,
   '-I' + sharedDir,
+  '-I' + sharedNsFoundationIncludeDir,
   '-I' + includeDir,
   '-I' + includeGlobalsDir,
   '-I' + includeSharedDir,
+  '-I' + includeLowLevelDir,
+  '-I' + includeExtensionsDir,
+  '-I' + includeStressExtDir,
   '-I' + foundationDir,
+  '-I' + sdkCommonDir,
+  '-I' + sdkGlobalsDir,
+  '-I' + sdkLowLevelDir,
+  '-I' + sdkStressDir,
   '-DSTRESS_SOLVER_FORCE_SCALAR=1',
   '-DSTRESS_SOLVER_NO_SIMD=1',
   '-D__linux__=1',

--- a/blast/js_stress_example/stress.js
+++ b/blast/js_stress_example/stress.js
@@ -19,6 +19,18 @@ export const StressFailure = Object.freeze({
   Shear: 'shear'
 });
 
+export const ExtForceMode = Object.freeze({
+  Force: 0,
+  Acceleration: 1
+});
+
+export const ExtDebugMode = Object.freeze({
+  Max: 0,
+  Compression: 1,
+  Tension: 2,
+  Shear: 3
+});
+
 export function vec3(x = 0.0, y = 0.0, z = 0.0) {
   return { x, y, z };
 }
@@ -164,6 +176,11 @@ export async function loadStressSolver({ module: moduleOptions } = {}) {
       return isNode ? fileURLToPathFn(url) : url.href;
     };
   }
+  if (isNode && !options.wasmBinary) {
+    const fs = await import('node:fs/promises');
+    const wasmUrl = new URL('stress_solver.wasm', distDirUrl);
+    options.wasmBinary = await fs.readFile(fileURLToPathFn(wasmUrl));
+  }
   options.print ??= (...args) => console.log('[blast-wasm]', ...args);
   options.printErr ??= (...args) => console.error('[blast-wasm]', ...args);
 
@@ -247,7 +264,11 @@ function createRuntime(module) {
     impulse: module.ccall('stress_sizeof_impulse', 'number', [], []),
     dataParams: module.ccall('stress_sizeof_data_params', 'number', [], []),
     solverParams: module.ccall('stress_sizeof_solver_params', 'number', [], []),
-    errorSq: module.ccall('stress_sizeof_error_sq', 'number', [], [])
+    errorSq: module.ccall('stress_sizeof_error_sq', 'number', [], []),
+    extNode: module.ccall('ext_stress_sizeof_ext_node_desc', 'number', [], []),
+    extBond: module.ccall('ext_stress_sizeof_ext_bond_desc', 'number', [], []),
+    extSettings: module.ccall('ext_stress_sizeof_ext_settings', 'number', [], []),
+    extDebugLine: module.ccall('ext_stress_sizeof_ext_debug_line', 'number', [], [])
   };
 
   const memory = new ModuleMemory(module);
@@ -258,10 +279,25 @@ function createRuntime(module) {
     vec3,
     StressLimits,
     StressFailure,
+    ExtForceMode,
+    ExtDebugMode,
     computeBondStress,
     defaultSolverParams: () => ({ maxIterations: 32, tolerance: 1.0e-6, warmStart: false }),
+    defaultExtSettings: () => ({
+      maxSolverIterationsPerFrame: 25,
+      graphReductionLevel: 0,
+      compressionElasticLimit: 1.0,
+      compressionFatalLimit: 2.0,
+      tensionElasticLimit: -1.0,
+      tensionFatalLimit: -1.0,
+      shearElasticLimit: -1.0,
+      shearFatalLimit: -1.0
+    }),
     createProcessor(description) {
       return new StressProcessor(module, memory, sizes, description);
+    },
+    createExtSolver(description) {
+      return new ExtStressSolver(module, memory, sizes, description);
     }
   };
 }
@@ -616,6 +652,193 @@ class StressProcessor {
   }
 }
 
+class ExtStressSolver {
+  constructor(module, memory, sizes, description) {
+    if (!description) {
+      throw new Error('ExtStressSolver description is required');
+    }
+
+    const nodes = description.nodes ?? [];
+    const bonds = description.bonds ?? [];
+    if (nodes.length === 0 || bonds.length === 0) {
+      throw new Error('ExtStressSolver requires at least one node and one bond');
+    }
+
+    this.module = module;
+    this.memory = memory;
+    this.sizes = sizes;
+
+    this.nodeCount = nodes.length;
+    this.bondCount = bonds.length;
+
+    const nodesPtr = memory.alloc(sizes.extNode * this.nodeCount);
+    const bondsPtr = memory.alloc(sizes.extBond * this.bondCount);
+    const settingsPtr = description.settings ? memory.alloc(sizes.extSettings) : 0;
+
+    try {
+      const view = memory.view();
+      nodes.forEach((node, index) => writeExtNode(view, nodesPtr + index * sizes.extNode, node));
+      bonds.forEach((bond, index) => writeExtBond(view, bondsPtr + index * sizes.extBond, bond));
+
+      if (settingsPtr) {
+        writeExtSettings(view, settingsPtr, description.settings);
+      }
+
+      const handle = module.ccall(
+        'ext_stress_solver_create',
+        'number',
+        ['number', 'number', 'number', 'number', 'number'],
+        [nodesPtr, this.nodeCount, bondsPtr, this.bondCount, settingsPtr]
+      );
+
+      if (!handle) {
+        throw new Error('Failed to create ExtStressSolver');
+      }
+
+      this.handle = handle >>> 0;
+      this._debugCapacity = Math.max(this.bondCount, 1);
+      this._debugPtr = memory.alloc(this._debugCapacity * sizes.extDebugLine);
+    } finally {
+      memory.free(nodesPtr);
+      memory.free(bondsPtr);
+      if (settingsPtr) {
+        memory.free(settingsPtr);
+      }
+    }
+  }
+
+  destroy() {
+    if (!this.handle) {
+      return;
+    }
+    this.module.ccall('ext_stress_solver_destroy', null, ['number'], [this.handle]);
+    this.handle = 0;
+    if (this._debugPtr) {
+      this.memory.free(this._debugPtr);
+      this._debugPtr = 0;
+    }
+  }
+
+  setSettings(settings) {
+    if (!settings || !this.handle) {
+      return;
+    }
+    const ptr = this.memory.alloc(this.sizes.extSettings);
+    try {
+      writeExtSettings(this.memory.view(), ptr, settings);
+      this.module.ccall('ext_stress_solver_set_settings', null, ['number', 'number'], [this.handle, ptr]);
+    } finally {
+      this.memory.free(ptr);
+    }
+  }
+
+  graphNodeCount() {
+    if (!this.handle) {
+      return 0;
+    }
+    return this.module.ccall('ext_stress_solver_graph_node_count', 'number', ['number'], [this.handle]) >>> 0;
+  }
+
+  bondCapacity() {
+    return this.bondCount;
+  }
+
+  reset() {
+    if (!this.handle) {
+      return;
+    }
+    this.module.ccall('ext_stress_solver_reset', null, ['number'], [this.handle]);
+  }
+
+  addForce(nodeIndex, localPosition, localForce, mode = ExtForceMode.Force) {
+    if (!this.handle) {
+      return;
+    }
+    const positionPtr = this.memory.alloc(this.sizes.vec3);
+    const forcePtr = this.memory.alloc(this.sizes.vec3);
+    try {
+      const view = this.memory.view();
+      writeVec3(view, positionPtr, localPosition ?? vec3());
+      writeVec3(view, forcePtr, localForce ?? vec3());
+      this.module.ccall(
+        'ext_stress_solver_add_force',
+        null,
+        ['number', 'number', 'number', 'number', 'number'],
+        [this.handle, nodeIndex >>> 0, positionPtr, forcePtr, mode >>> 0]
+      );
+    } finally {
+      this.memory.free(positionPtr);
+      this.memory.free(forcePtr);
+    }
+  }
+
+  addGravity(localGravity) {
+    if (!this.handle) {
+      return;
+    }
+    const gravityPtr = this.memory.alloc(this.sizes.vec3);
+    try {
+      writeVec3(this.memory.view(), gravityPtr, localGravity ?? vec3());
+      this.module.ccall('ext_stress_solver_add_gravity', null, ['number', 'number'], [this.handle, gravityPtr]);
+    } finally {
+      this.memory.free(gravityPtr);
+    }
+  }
+
+  update() {
+    if (!this.handle) {
+      return;
+    }
+    this.module.ccall('ext_stress_solver_update', null, ['number'], [this.handle]);
+  }
+
+  overstressedBondCount() {
+    if (!this.handle) {
+      return 0;
+    }
+    return this.module.ccall('ext_stress_solver_overstressed_bond_count', 'number', ['number'], [this.handle]) >>> 0;
+  }
+
+  fillDebugRender({ mode = ExtDebugMode.Max, scale = 1.0 } = {}) {
+    if (!this.handle || !this._debugPtr) {
+      return [];
+    }
+    const capacity = this._debugCapacity;
+    const count = this.module.ccall(
+      'ext_stress_solver_fill_debug_render',
+      'number',
+      ['number', 'number', 'number', 'number', 'number'],
+      [this.handle, mode >>> 0, scale, this._debugPtr, capacity]
+    );
+    const result = [];
+    if (count <= 0) {
+      return result;
+    }
+    const view = this.memory.view();
+    for (let i = 0; i < count; ++i) {
+      const base = this._debugPtr + i * this.sizes.extDebugLine;
+      result.push(readExtDebugLine(view, base));
+    }
+    return result;
+  }
+
+  stressError() {
+    if (!this.handle) {
+      return { lin: 0.0, ang: 0.0 };
+    }
+    const lin = this.module.ccall('ext_stress_solver_get_linear_error', 'number', ['number'], [this.handle]);
+    const ang = this.module.ccall('ext_stress_solver_get_angular_error', 'number', ['number'], [this.handle]);
+    return { lin, ang };
+  }
+
+  converged() {
+    if (!this.handle) {
+      return false;
+    }
+    return this.module.ccall('ext_stress_solver_converged', 'number', ['number'], [this.handle]) !== 0;
+  }
+}
+
 function writeNode(view, base, node) {
   writeVec3(view, base, node.com ?? vec3());
   view.setFloat32(base + 12, node.mass ?? 0.0, true);
@@ -652,6 +875,40 @@ function writeVec3(view, base, value) {
 
 function readVec3(view, base) {
   return vec3(view.getFloat32(base, true), view.getFloat32(base + 4, true), view.getFloat32(base + 8, true));
+}
+
+function writeExtNode(view, base, node) {
+  writeVec3(view, base, node.centroid ?? vec3());
+  view.setFloat32(base + 12, node.mass ?? 0.0, true);
+  view.setFloat32(base + 16, node.volume ?? Math.max(node.mass ?? 0.0, 1.0), true);
+}
+
+function writeExtBond(view, base, bond) {
+  writeVec3(view, base, bond.centroid ?? vec3());
+  writeVec3(view, base + 12, bond.normal ?? vec3(0.0, 1.0, 0.0));
+  view.setFloat32(base + 24, bond.area ?? 1.0, true);
+  view.setUint32(base + 28, bond.node0 >>> 0, true);
+  view.setUint32(base + 32, bond.node1 >>> 0, true);
+}
+
+function writeExtSettings(view, base, settings) {
+  view.setUint32(base, settings.maxSolverIterationsPerFrame >>> 0, true);
+  view.setUint32(base + 4, settings.graphReductionLevel >>> 0, true);
+  view.setFloat32(base + 8, settings.compressionElasticLimit ?? 1.0, true);
+  view.setFloat32(base + 12, settings.compressionFatalLimit ?? 2.0, true);
+  view.setFloat32(base + 16, settings.tensionElasticLimit ?? -1.0, true);
+  view.setFloat32(base + 20, settings.tensionFatalLimit ?? -1.0, true);
+  view.setFloat32(base + 24, settings.shearElasticLimit ?? -1.0, true);
+  view.setFloat32(base + 28, settings.shearFatalLimit ?? -1.0, true);
+}
+
+function readExtDebugLine(view, base) {
+  return {
+    p0: readVec3(view, base),
+    p1: readVec3(view, base + 12),
+    color0: view.getUint32(base + 24, true),
+    color1: view.getUint32(base + 28, true)
+  };
 }
 
 function createImpulse() {

--- a/blast/rust_stress_example/ffi/ext_stress_bridge.cpp
+++ b/blast/rust_stress_example/ffi/ext_stress_bridge.cpp
@@ -1,0 +1,474 @@
+#include "ext_stress_bridge.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <new>
+#include <vector>
+
+#include "NvBlast.h"
+#include "NvBlastGlobals.h"
+#include "NvBlastSupportGraph.h"
+#include "NvBlastExtStressSolver.h"
+
+namespace
+{
+
+using namespace Nv::Blast;
+
+struct ExtStressSolverHandleImpl
+{
+    ExtStressSolver* solver{nullptr};
+    NvBlastAsset* asset{nullptr};
+    NvBlastFamily* family{nullptr};
+    NvBlastActor* actor{nullptr};
+
+    void* assetMem{nullptr};
+    void* assetScratch{nullptr};
+    void* familyMem{nullptr};
+    void* actorScratch{nullptr};
+
+    std::vector<uint32_t> inputToGraph;
+    std::vector<uint32_t> graphNodeIndices;
+};
+
+inline StressVec3 toStressVec3(const NvcVec3& value)
+{
+    StressVec3 result;
+    result.x = value.x;
+    result.y = value.y;
+    result.z = value.z;
+    return result;
+}
+
+inline NvcVec3 toNvcVec3(const StressVec3& value)
+{
+    return NvcVec3{value.x, value.y, value.z};
+}
+
+inline ExtForceMode::Enum toForceMode(uint32_t mode)
+{
+    switch (mode)
+    {
+    case ExtForceMode::ACCELERATION:
+        return ExtForceMode::ACCELERATION;
+    case ExtForceMode::FORCE:
+    default:
+        return ExtForceMode::FORCE;
+    }
+}
+
+inline ExtStressSolverSettings toSettings(const ExtStressSolverSettingsDesc* settingsDesc)
+{
+    ExtStressSolverSettings settings;
+    if (!settingsDesc)
+    {
+        return settings;
+    }
+
+    settings.maxSolverIterationsPerFrame = settingsDesc->max_solver_iterations_per_frame;
+    settings.graphReductionLevel = settingsDesc->graph_reduction_level;
+    settings.compressionElasticLimit = settingsDesc->compression_elastic_limit;
+    settings.compressionFatalLimit = settingsDesc->compression_fatal_limit;
+    settings.tensionElasticLimit = settingsDesc->tension_elastic_limit;
+    settings.tensionFatalLimit = settingsDesc->tension_fatal_limit;
+    settings.shearElasticLimit = settingsDesc->shear_elastic_limit;
+    settings.shearFatalLimit = settingsDesc->shear_fatal_limit;
+    return settings;
+}
+
+void releaseHandle(ExtStressSolverHandleImpl* handle)
+{
+    if (!handle)
+    {
+        return;
+    }
+
+    if (handle->solver)
+    {
+        handle->solver->release();
+        handle->solver = nullptr;
+    }
+
+    if (handle->actorScratch)
+    {
+        NVBLAST_FREE(handle->actorScratch);
+        handle->actorScratch = nullptr;
+    }
+
+    if (handle->familyMem)
+    {
+        NVBLAST_FREE(handle->familyMem);
+        handle->familyMem = nullptr;
+        handle->family = nullptr;
+    }
+
+    if (handle->assetScratch)
+    {
+        NVBLAST_FREE(handle->assetScratch);
+        handle->assetScratch = nullptr;
+    }
+
+    if (handle->assetMem)
+    {
+        NVBLAST_FREE(handle->assetMem);
+        handle->assetMem = nullptr;
+        handle->asset = nullptr;
+    }
+
+    delete handle;
+}
+
+void stressLog(int type, const char* msg, const char* file, int line)
+{
+    NV_UNUSED(type);
+    NV_UNUSED(file);
+    NV_UNUSED(line);
+#ifdef DEBUG
+    if (msg)
+    {
+        std::fprintf(stderr, "[Blast][ExtStress] %s (%s:%d)\n", msg, file ? file : "", line);
+    }
+#else
+    NV_UNUSED(msg);
+#endif
+}
+
+const NvBlastLog kLogFn = stressLog;
+
+} // namespace
+
+extern "C" ExtStressSolverHandle*
+ext_stress_solver_create(const ExtStressNodeDesc* nodes,
+                        uint32_t node_count,
+                        const ExtStressBondDesc* bonds,
+                        uint32_t bond_count,
+                        const ExtStressSolverSettingsDesc* settingsDesc)
+{
+    if (!nodes || node_count == 0U || !bonds || bond_count == 0U)
+    {
+        return nullptr;
+    }
+
+    ExtStressSolverHandleImpl* handle = new (std::nothrow) ExtStressSolverHandleImpl();
+    if (!handle)
+    {
+        return nullptr;
+    }
+
+    std::vector<NvBlastChunkDesc> chunkDescs;
+    chunkDescs.resize(node_count + 1U);
+
+    NvBlastChunkDesc& rootChunk = chunkDescs[0];
+    rootChunk.centroid[0] = 0.0f;
+    rootChunk.centroid[1] = 0.0f;
+    rootChunk.centroid[2] = 0.0f;
+    rootChunk.volume = std::max(1.0f, static_cast<float>(node_count));
+    rootChunk.parentChunkDescIndex = UINT32_MAX;
+    rootChunk.flags = NvBlastChunkDesc::NoFlags;
+    rootChunk.userData = 0U;
+
+    for (uint32_t i = 0; i < node_count; ++i)
+    {
+        NvBlastChunkDesc& desc = chunkDescs[i + 1];
+        desc.centroid[0] = nodes[i].centroid.x;
+        desc.centroid[1] = nodes[i].centroid.y;
+        desc.centroid[2] = nodes[i].centroid.z;
+        desc.volume = nodes[i].volume > 0.0f ? nodes[i].volume : std::max(nodes[i].mass, 1.0f);
+        desc.parentChunkDescIndex = 0;
+        desc.flags = NvBlastChunkDesc::SupportFlag;
+        desc.userData = i;
+    }
+
+    std::vector<NvBlastBondDesc> bondDescs;
+    bondDescs.resize(bond_count);
+    for (uint32_t i = 0; i < bond_count; ++i)
+    {
+        NvBlastBondDesc& desc = bondDescs[i];
+        desc.chunkIndices[0] = bonds[i].node0 + 1U;
+        desc.chunkIndices[1] = bonds[i].node1 + 1U;
+
+        desc.bond.centroid[0] = bonds[i].centroid.x;
+        desc.bond.centroid[1] = bonds[i].centroid.y;
+        desc.bond.centroid[2] = bonds[i].centroid.z;
+
+        desc.bond.normal[0] = bonds[i].normal.x;
+        desc.bond.normal[1] = bonds[i].normal.y;
+        desc.bond.normal[2] = bonds[i].normal.z;
+
+        desc.bond.area = bonds[i].area > 0.0f ? bonds[i].area : 1.0f;
+        desc.bond.userData = i;
+    }
+
+    NvBlastAssetDesc assetDesc;
+    assetDesc.chunkCount = static_cast<uint32_t>(chunkDescs.size());
+    assetDesc.chunkDescs = chunkDescs.data();
+    assetDesc.bondCount = static_cast<uint32_t>(bondDescs.size());
+    assetDesc.bondDescs = bondDescs.data();
+
+    const size_t scratchSize = NvBlastGetRequiredScratchForCreateAsset(&assetDesc, kLogFn);
+    handle->assetScratch = NVBLAST_ALLOC(scratchSize);
+    if (!handle->assetScratch)
+    {
+        releaseHandle(handle);
+        return nullptr;
+    }
+
+    const size_t assetMemSize = NvBlastGetAssetMemorySize(&assetDesc, kLogFn);
+    handle->assetMem = NVBLAST_ALLOC(assetMemSize);
+    if (!handle->assetMem)
+    {
+        releaseHandle(handle);
+        return nullptr;
+    }
+
+    handle->asset = NvBlastCreateAsset(handle->assetMem, &assetDesc, handle->assetScratch, kLogFn);
+    if (!handle->asset)
+    {
+        releaseHandle(handle);
+        return nullptr;
+    }
+
+    const size_t familyMemSize = NvBlastAssetGetFamilyMemorySize(handle->asset, kLogFn);
+    handle->familyMem = NVBLAST_ALLOC(familyMemSize);
+    if (!handle->familyMem)
+    {
+        releaseHandle(handle);
+        return nullptr;
+    }
+
+    handle->family = NvBlastAssetCreateFamily(handle->familyMem, handle->asset, kLogFn);
+    if (!handle->family)
+    {
+        releaseHandle(handle);
+        return nullptr;
+    }
+
+    NvBlastActorDesc actorDesc{};
+    actorDesc.uniformInitialBondHealth = 1.0f;
+    actorDesc.uniformInitialLowerSupportChunkHealth = 1.0f;
+
+    const size_t actorScratchSize = NvBlastFamilyGetRequiredScratchForCreateFirstActor(handle->family, kLogFn);
+    handle->actorScratch = NVBLAST_ALLOC(actorScratchSize);
+    if (!handle->actorScratch)
+    {
+        releaseHandle(handle);
+        return nullptr;
+    }
+
+    handle->actor = NvBlastFamilyCreateFirstActor(handle->family, &actorDesc, handle->actorScratch, kLogFn);
+    if (!handle->actor)
+    {
+        releaseHandle(handle);
+        return nullptr;
+    }
+
+    ExtStressSolverSettings settings = toSettings(settingsDesc);
+    handle->solver = ExtStressSolver::create(*handle->family, settings);
+    if (!handle->solver)
+    {
+        releaseHandle(handle);
+        return nullptr;
+    }
+
+    const NvBlastSupportGraph supportGraph = NvBlastAssetGetSupportGraph(handle->asset, kLogFn);
+    handle->inputToGraph.assign(node_count, UINT32_MAX);
+    handle->graphNodeIndices.resize(supportGraph.nodeCount);
+    for (uint32_t graphIndex = 0; graphIndex < supportGraph.nodeCount; ++graphIndex)
+    {
+        handle->graphNodeIndices[graphIndex] = graphIndex;
+        const uint32_t chunkIndex = supportGraph.chunkIndices[graphIndex];
+        if (chunkIndex > 0 && chunkIndex <= node_count)
+        {
+            const uint32_t inputIndex = chunkIndex - 1U;
+            handle->inputToGraph[inputIndex] = graphIndex;
+            const ExtStressNodeDesc& nodeDesc = nodes[inputIndex];
+            handle->solver->setNodeInfo(graphIndex,
+                                        nodeDesc.mass,
+                                        nodeDesc.volume > 0.0f ? nodeDesc.volume : std::max(nodeDesc.mass, 1.0f),
+                                        toNvcVec3(nodeDesc.centroid));
+        }
+    }
+
+    handle->solver->notifyActorCreated(*handle->actor);
+
+    return reinterpret_cast<ExtStressSolverHandle*>(handle);
+}
+
+extern "C" void
+ext_stress_solver_destroy(ExtStressSolverHandle* handlePtr)
+{
+    auto* handle = reinterpret_cast<ExtStressSolverHandleImpl*>(handlePtr);
+    releaseHandle(handle);
+}
+
+extern "C" void
+ext_stress_solver_set_settings(ExtStressSolverHandle* handlePtr, const ExtStressSolverSettingsDesc* settingsDesc)
+{
+    auto* handle = reinterpret_cast<ExtStressSolverHandleImpl*>(handlePtr);
+    if (!handle || !handle->solver)
+    {
+        return;
+    }
+
+    ExtStressSolverSettings settings = toSettings(settingsDesc);
+    handle->solver->setSettings(settings);
+}
+
+extern "C" uint32_t
+ext_stress_solver_graph_node_count(const ExtStressSolverHandle* handlePtr)
+{
+    const auto* handle = reinterpret_cast<const ExtStressSolverHandleImpl*>(handlePtr);
+    return handle ? static_cast<uint32_t>(handle->graphNodeIndices.size()) : 0U;
+}
+
+extern "C" uint32_t
+ext_stress_solver_bond_count(const ExtStressSolverHandle* handlePtr)
+{
+    const auto* handle = reinterpret_cast<const ExtStressSolverHandleImpl*>(handlePtr);
+    return (handle && handle->solver) ? handle->solver->getBondCount() : 0U;
+}
+
+extern "C" void
+ext_stress_solver_reset(ExtStressSolverHandle* handlePtr)
+{
+    auto* handle = reinterpret_cast<ExtStressSolverHandleImpl*>(handlePtr);
+    if (!handle || !handle->solver)
+    {
+        return;
+    }
+    handle->solver->reset();
+}
+
+extern "C" void
+ext_stress_solver_add_force(ExtStressSolverHandle* handlePtr,
+                           uint32_t node_index,
+                           const StressVec3* local_position,
+                           const StressVec3* local_force,
+                           uint32_t mode)
+{
+    auto* handle = reinterpret_cast<ExtStressSolverHandleImpl*>(handlePtr);
+    if (!handle || !handle->solver || node_index >= handle->inputToGraph.size())
+    {
+        return;
+    }
+
+    const uint32_t graphIndex = handle->inputToGraph[node_index];
+    if (graphIndex == UINT32_MAX)
+    {
+        return;
+    }
+
+    NV_UNUSED(local_position);
+    const NvcVec3 force = local_force ? toNvcVec3(*local_force) : NvcVec3{0.0f, 0.0f, 0.0f};
+
+    handle->solver->addForce(graphIndex, force, toForceMode(mode));
+}
+
+extern "C" void
+ext_stress_solver_add_gravity(ExtStressSolverHandle* handlePtr, const StressVec3* local_gravity)
+{
+    auto* handle = reinterpret_cast<ExtStressSolverHandleImpl*>(handlePtr);
+    if (!handle || !handle->solver || !handle->actor)
+    {
+        return;
+    }
+
+    const NvcVec3 gravity = local_gravity ? toNvcVec3(*local_gravity) : NvcVec3{0.0f, 0.0f, 0.0f};
+    handle->solver->addGravity(*handle->actor, gravity);
+}
+
+extern "C" void
+ext_stress_solver_update(ExtStressSolverHandle* handlePtr)
+{
+    auto* handle = reinterpret_cast<ExtStressSolverHandleImpl*>(handlePtr);
+    if (!handle || !handle->solver)
+    {
+        return;
+    }
+    handle->solver->update();
+}
+
+extern "C" uint32_t
+ext_stress_solver_overstressed_bond_count(const ExtStressSolverHandle* handlePtr)
+{
+    const auto* handle = reinterpret_cast<const ExtStressSolverHandleImpl*>(handlePtr);
+    return (handle && handle->solver) ? handle->solver->getOverstressedBondCount() : 0U;
+}
+
+extern "C" uint32_t
+ext_stress_solver_fill_debug_render(const ExtStressSolverHandle* handlePtr,
+                                    uint32_t mode,
+                                    float scale,
+                                    ExtStressDebugLine* out_lines,
+                                    uint32_t max_lines)
+{
+    const auto* handle = reinterpret_cast<const ExtStressSolverHandleImpl*>(handlePtr);
+    if (!handle || !handle->solver || !out_lines || max_lines == 0U)
+    {
+        return 0U;
+    }
+
+    const ExtStressSolver::DebugBuffer buffer = handle->solver->fillDebugRender(
+        handle->graphNodeIndices.data(),
+        static_cast<uint32_t>(handle->graphNodeIndices.size()),
+        static_cast<ExtStressSolver::DebugRenderMode>(mode),
+        scale);
+
+    const uint32_t count = std::min(buffer.lineCount, max_lines);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        const ExtStressSolver::DebugLine& line = buffer.lines[i];
+        out_lines[i].p0 = toStressVec3(line.pos0);
+        out_lines[i].p1 = toStressVec3(line.pos1);
+        out_lines[i].color0 = line.color0;
+        out_lines[i].color1 = line.color1;
+    }
+
+    return count;
+}
+
+extern "C" float
+ext_stress_solver_get_linear_error(const ExtStressSolverHandle* handlePtr)
+{
+    const auto* handle = reinterpret_cast<const ExtStressSolverHandleImpl*>(handlePtr);
+    return (handle && handle->solver) ? handle->solver->getStressErrorLinear() : 0.0f;
+}
+
+extern "C" float
+ext_stress_solver_get_angular_error(const ExtStressSolverHandle* handlePtr)
+{
+    const auto* handle = reinterpret_cast<const ExtStressSolverHandleImpl*>(handlePtr);
+    return (handle && handle->solver) ? handle->solver->getStressErrorAngular() : 0.0f;
+}
+
+extern "C" uint8_t
+ext_stress_solver_converged(const ExtStressSolverHandle* handlePtr)
+{
+    const auto* handle = reinterpret_cast<const ExtStressSolverHandleImpl*>(handlePtr);
+    return (handle && handle->solver && handle->solver->converged()) ? 1U : 0U;
+}
+
+extern "C" uint32_t
+ext_stress_sizeof_ext_node_desc()
+{
+    return static_cast<uint32_t>(sizeof(ExtStressNodeDesc));
+}
+
+extern "C" uint32_t
+ext_stress_sizeof_ext_bond_desc()
+{
+    return static_cast<uint32_t>(sizeof(ExtStressBondDesc));
+}
+
+extern "C" uint32_t
+ext_stress_sizeof_ext_settings()
+{
+    return static_cast<uint32_t>(sizeof(ExtStressSolverSettingsDesc));
+}
+
+extern "C" uint32_t
+ext_stress_sizeof_ext_debug_line()
+{
+    return static_cast<uint32_t>(sizeof(ExtStressDebugLine));
+}
+

--- a/blast/rust_stress_example/ffi/ext_stress_bridge.h
+++ b/blast/rust_stress_example/ffi/ext_stress_bridge.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "stress_bridge.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ExtStressSolverHandle;
+
+typedef struct ExtStressNodeDesc {
+    StressVec3 centroid;
+    float mass;
+    float volume;
+} ExtStressNodeDesc;
+
+typedef struct ExtStressBondDesc {
+    StressVec3 centroid;
+    StressVec3 normal;
+    float area;
+    uint32_t node0;
+    uint32_t node1;
+} ExtStressBondDesc;
+
+typedef struct ExtStressSolverSettingsDesc {
+    uint32_t max_solver_iterations_per_frame;
+    uint32_t graph_reduction_level;
+    float compression_elastic_limit;
+    float compression_fatal_limit;
+    float tension_elastic_limit;
+    float tension_fatal_limit;
+    float shear_elastic_limit;
+    float shear_fatal_limit;
+} ExtStressSolverSettingsDesc;
+
+typedef struct ExtStressDebugLine {
+    StressVec3 p0;
+    StressVec3 p1;
+    uint32_t color0;
+    uint32_t color1;
+} ExtStressDebugLine;
+
+ExtStressSolverHandle* ext_stress_solver_create(const ExtStressNodeDesc* nodes,
+                                                uint32_t node_count,
+                                                const ExtStressBondDesc* bonds,
+                                                uint32_t bond_count,
+                                                const ExtStressSolverSettingsDesc* settings);
+
+void ext_stress_solver_destroy(ExtStressSolverHandle* handle);
+
+void ext_stress_solver_set_settings(ExtStressSolverHandle* handle,
+                                    const ExtStressSolverSettingsDesc* settings);
+
+uint32_t ext_stress_solver_graph_node_count(const ExtStressSolverHandle* handle);
+
+uint32_t ext_stress_solver_bond_count(const ExtStressSolverHandle* handle);
+
+void ext_stress_solver_reset(ExtStressSolverHandle* handle);
+
+void ext_stress_solver_add_force(ExtStressSolverHandle* handle,
+                                 uint32_t node_index,
+                                 const StressVec3* local_position,
+                                 const StressVec3* local_force,
+                                 uint32_t mode);
+
+void ext_stress_solver_add_gravity(ExtStressSolverHandle* handle,
+                                   const StressVec3* local_gravity);
+
+void ext_stress_solver_update(ExtStressSolverHandle* handle);
+
+uint32_t ext_stress_solver_overstressed_bond_count(const ExtStressSolverHandle* handle);
+
+uint32_t ext_stress_solver_fill_debug_render(const ExtStressSolverHandle* handle,
+                                             uint32_t mode,
+                                             float scale,
+                                             ExtStressDebugLine* out_lines,
+                                             uint32_t max_lines);
+
+float ext_stress_solver_get_linear_error(const ExtStressSolverHandle* handle);
+
+float ext_stress_solver_get_angular_error(const ExtStressSolverHandle* handle);
+
+uint8_t ext_stress_solver_converged(const ExtStressSolverHandle* handle);
+
+uint32_t ext_stress_sizeof_ext_node_desc();
+uint32_t ext_stress_sizeof_ext_bond_desc();
+uint32_t ext_stress_sizeof_ext_settings();
+uint32_t ext_stress_sizeof_ext_debug_line();
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/blast/source/sdk/extensions/stress/NvBlastExtStressSolver.cpp
+++ b/blast/source/sdk/extensions/stress/NvBlastExtStressSolver.cpp
@@ -43,6 +43,7 @@
 #include "simd/simd_device_query.h"
 
 #include <algorithm>
+#include <cmath>
 
 #define USE_SCALAR_IMPL 0
 #define WARM_START 1
@@ -372,7 +373,7 @@ public:
         const float twistContribution = twist * 2.0f / nodeDist;
         stressShear += twistContribution;
         const float bendContribution = bend * 2.0f / nodeDist;
-        stressNormal += copysignf(bendContribution, stressNormal);
+        stressNormal += std::copysign(bendContribution, stressNormal);
     }
 
     float mapStressToRange(float stress, float elasticLimit, float fatalLimit) const
@@ -633,7 +634,7 @@ private:
 
                     // Align normal(s) with node displacement, so that compressive/tensile distinction is correct
                     const nvidia::NvVec3 assetBondNormal(blastBond.normal[0], blastBond.normal[1], blastBond.normal[2]);
-                    const nvidia::NvVec3 blastBondNormal = std::copysignf(1.0f, assetBondNormal.dot(nodeDisp))*assetBondNormal;
+                    const nvidia::NvVec3 blastBondNormal = std::copysign(1.0f, assetBondNormal.dot(nodeDisp))*assetBondNormal;
 
                     const nvidia::NvVec3 blastBondCentroid(blastBond.centroid[0], blastBond.centroid[1], blastBond.centroid[2]);
 
@@ -889,7 +890,7 @@ private:
             bond.centroid = *(NvVec3*)bonds[bond.blastBondIndex].centroid;
 
             // fix normal direction to point from node0 to node1
-            bond.normal *= std::copysignf(1.0f, bond.normal.dot(node1.localPos - node1.localPos));
+            bond.normal *= std::copysign(1.0f, bond.normal.dot(node1.localPos - node1.localPos));
 
             if (node0.solverNode == node1.solverNode)
                 continue; // skip (internal)

--- a/blast/source/shared/NsFoundation/include/NsArray.h
+++ b/blast/source/shared/NsFoundation/include/NsArray.h
@@ -32,7 +32,16 @@
 #include "NsBasicTemplates.h"
 #include "NvIntrinsics.h"
 
-#if NV_LINUX || NV_ANDROID || (NV_IOS && !NV_A64) || NV_OSX || NV_PS3 || NV_PSP2 || NV_WIIU
+#if defined(__EMSCRIPTEN__)
+#include <type_traits>
+namespace std
+{
+namespace tr1
+{
+using std::is_pod;
+}
+}
+#elif NV_LINUX || NV_ANDROID || (NV_IOS && !NV_A64) || NV_OSX || NV_PS3 || NV_PSP2 || NV_WIIU
 #include <tr1/type_traits>
 #elif NV_WINRT || NV_XBOXONE || (NV_IOS && NV_A64) || NV_WIN64 || NV_X360 || NV_WIN32 || NV_PS4
 #include <type_traits>

--- a/blast/source/shared/NsFoundation/include/NsFPU.h
+++ b/blast/source/shared/NsFoundation/include/NsFPU.h
@@ -82,7 +82,11 @@ NV_FORCE_INLINE float NV_FR(const unsigned int x)
 #define NV_FPU_GUARD shdfnd::FPUGuard scopedFpGuard;
 #define NV_SIMD_GUARD shdfnd::SIMDGuard scopedFpGuard;
 
+#if defined(__EMSCRIPTEN__)
+#define NV_SUPPORT_GUARDS 0
+#else
 #define NV_SUPPORT_GUARDS (NV_WINDOWS_FAMILY || NV_XBOXONE || NV_LINUX || NV_PS4 || NV_OSX)
+#endif
 
 namespace nvidia
 {
@@ -125,6 +129,14 @@ NV_FOUNDATION_API void disableFPExceptions();
 
 #if NV_WINDOWS_FAMILY || NV_XBOXONE
 #include "platform/windows/NsWindowsFPU.h"
+#elif defined(__EMSCRIPTEN__)
+NV_INLINE nvidia::shdfnd::SIMDGuard::SIMDGuard()
+{
+}
+
+NV_INLINE nvidia::shdfnd::SIMDGuard::~SIMDGuard()
+{
+}
 #elif NV_LINUX || NV_PS4 || NV_OSX
 #include "platform/unix/NsUnixFPU.h"
 #else


### PR DESCRIPTION
## Summary
- add `ext-cube-projectile.js` to showcase a fractured cube that breaks under a projectile impact using the ExtStressSolver helpers from Node.js
- add `ext-bridge-cars.js` to simulate a segmented beam bridge that fails when heavy car loads traverse the span, logging per-step solver diagnostics
- document the new demos in the stress example README and expose npm scripts for running them

## Testing
- npm run demo:ext-cube
- npm run demo:ext-bridge
- npm run demo:ext


------
https://chatgpt.com/codex/tasks/task_e_68e26d4b7e14832fac4fe9d6d1a2c328