### PR TITLE
Make preview page mobile responsive with collapsible sidebar

### DIFF
--- a/blast/js_stress_example/bridge-split-demo.html
+++ b/blast/js_stress_example/bridge-split-demo.html
@@ -381,29 +381,48 @@
       </aside>
     </main>
     <script>
-      // Mobile sidebar toggle
+      // Sidebar toggle — works on both desktop and mobile
       (function() {
         var toggle = document.getElementById('sidebar-toggle');
         var sidebar = document.getElementById('sidebar');
         var backdrop = document.getElementById('sidebar-backdrop');
+        var layout = document.querySelector('.layout');
+        var mql = window.matchMedia('(max-width: 960px)');
+
+        function isMobile() { return mql.matches; }
+
         function closeSidebar() {
-          sidebar.classList.remove('open');
           toggle.classList.remove('active');
-          backdrop.classList.remove('visible');
-        }
-        function openSidebar() {
-          sidebar.classList.add('open');
-          toggle.classList.add('active');
-          backdrop.classList.add('visible');
-        }
-        toggle.addEventListener('click', function() {
-          if (sidebar.classList.contains('open')) {
-            closeSidebar();
+          if (isMobile()) {
+            sidebar.classList.remove('open');
+            backdrop.classList.remove('visible');
           } else {
-            openSidebar();
+            layout.classList.add('sidebar-hidden');
           }
+        }
+
+        function openSidebar() {
+          toggle.classList.add('active');
+          if (isMobile()) {
+            sidebar.classList.add('open');
+            backdrop.classList.add('visible');
+          } else {
+            layout.classList.remove('sidebar-hidden');
+          }
+        }
+
+        function isOpen() {
+          if (isMobile()) return sidebar.classList.contains('open');
+          return !layout.classList.contains('sidebar-hidden');
+        }
+
+        toggle.addEventListener('click', function() {
+          if (isOpen()) closeSidebar(); else openSidebar();
         });
         backdrop.addEventListener('click', closeSidebar);
+
+        // Sync toggle icon state on load — desktop sidebar starts open
+        if (!isMobile()) toggle.classList.add('active');
       })();
     </script>
     <script type="module" src="./dist/split-bridge-stress.js"></script>

--- a/blast/js_stress_example/bridge-split-demo.html
+++ b/blast/js_stress_example/bridge-split-demo.html
@@ -22,7 +22,12 @@
         <canvas id="bridge-canvas"></canvas>
         <div id="overlay" class="overlay"></div>
       </section>
-      <aside class="sidebar">
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle settings panel">
+        <span class="icon-open">☰</span>
+        <span class="icon-close">✕</span>
+      </button>
+      <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
+      <aside class="sidebar" id="sidebar">
         <header>
           <h1>🌉 Bridge Stress Tester</h1>
           <p>Adjust parameters in real-time. Change bridge → click Reset.</p>
@@ -375,6 +380,32 @@
         </section>
       </aside>
     </main>
+    <script>
+      // Mobile sidebar toggle
+      (function() {
+        var toggle = document.getElementById('sidebar-toggle');
+        var sidebar = document.getElementById('sidebar');
+        var backdrop = document.getElementById('sidebar-backdrop');
+        function closeSidebar() {
+          sidebar.classList.remove('open');
+          toggle.classList.remove('active');
+          backdrop.classList.remove('visible');
+        }
+        function openSidebar() {
+          sidebar.classList.add('open');
+          toggle.classList.add('active');
+          backdrop.classList.add('visible');
+        }
+        toggle.addEventListener('click', function() {
+          if (sidebar.classList.contains('open')) {
+            closeSidebar();
+          } else {
+            openSidebar();
+          }
+        });
+        backdrop.addEventListener('click', closeSidebar);
+      })();
+    </script>
     <script type="module" src="./dist/split-bridge-stress.js"></script>
   </body>
 </html>

--- a/blast/js_stress_example/styles/bridge-demo.css
+++ b/blast/js_stress_example/styles/bridge-demo.css
@@ -1,3 +1,7 @@
+body {
+  margin: 0;
+}
+
 .layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 360px;
@@ -409,9 +413,9 @@
   background: rgba(91, 198, 255, 0.35);
 }
 
-/* Mobile sidebar toggle button */
+/* Sidebar toggle button — always visible */
 .sidebar-toggle {
-  display: none;
+  display: flex;
   position: fixed;
   top: 0.75rem;
   right: 0.75rem;
@@ -437,23 +441,51 @@
   border-color: rgba(91, 198, 255, 0.5);
 }
 
-.sidebar-toggle .icon-open,
+/* Icon state: show open icon by default, close when active */
+.sidebar-toggle .icon-open  { display: block; }
 .sidebar-toggle .icon-close { display: none; }
+.sidebar-toggle.active .icon-open  { display: none; }
+.sidebar-toggle.active .icon-close { display: block; }
 
+/* Desktop: sidebar starts visible; toggle button repositions when sidebar is open */
+.sidebar-toggle.active {
+  right: calc(360px + 0.75rem);
+}
+
+/* Desktop collapsed state: hide sidebar column, canvas goes full width */
+.layout.sidebar-hidden {
+  grid-template-columns: 1fr;
+}
+
+.layout.sidebar-hidden .sidebar {
+  display: none;
+}
+
+/* Backdrop — only used on mobile */
+.sidebar-backdrop {
+  display: none;
+}
+
+/* ── Mobile overrides ── */
 @media (max-width: 960px) {
   .layout {
     grid-template-columns: 1fr;
     grid-template-rows: 1fr;
   }
 
-  .sidebar-toggle {
+  /* Undo the desktop column-hide approach; mobile uses overlay */
+  .layout.sidebar-hidden {
+    grid-template-columns: 1fr;
+  }
+  .layout.sidebar-hidden .sidebar {
     display: flex;
   }
 
-  .sidebar-toggle .icon-open { display: block; }
-  .sidebar-toggle .icon-close { display: none; }
-  .sidebar-toggle.active .icon-open { display: none; }
-  .sidebar-toggle.active .icon-close { display: block; }
+  /* Toggle button always top-right on mobile */
+  .sidebar-toggle,
+  .sidebar-toggle.active {
+    right: 0.75rem;
+  }
 
   .viewport {
     grid-column: 1;
@@ -477,7 +509,6 @@
     transform: translateX(0);
   }
 
-  /* Backdrop overlay when sidebar is open */
   .sidebar-backdrop {
     display: none;
     position: fixed;

--- a/blast/js_stress_example/styles/bridge-demo.css
+++ b/blast/js_stress_example/styles/bridge-demo.css
@@ -409,13 +409,85 @@
   background: rgba(91, 198, 255, 0.35);
 }
 
+/* Mobile sidebar toggle button */
+.sidebar-toggle {
+  display: none;
+  position: fixed;
+  top: 0.75rem;
+  right: 0.75rem;
+  z-index: 1001;
+  width: 44px;
+  height: 44px;
+  border: 1px solid rgba(91, 198, 255, 0.3);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(12px);
+  color: #7ec1ff;
+  font-size: 1.4rem;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  transition: background 200ms ease-out, border-color 200ms ease-out;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.sidebar-toggle:hover,
+.sidebar-toggle:active {
+  background: rgba(91, 198, 255, 0.2);
+  border-color: rgba(91, 198, 255, 0.5);
+}
+
+.sidebar-toggle .icon-open,
+.sidebar-toggle .icon-close { display: none; }
+
 @media (max-width: 960px) {
   .layout {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(0, 1fr) auto;
+    grid-template-rows: 1fr;
   }
+
+  .sidebar-toggle {
+    display: flex;
+  }
+
+  .sidebar-toggle .icon-open { display: block; }
+  .sidebar-toggle .icon-close { display: none; }
+  .sidebar-toggle.active .icon-open { display: none; }
+  .sidebar-toggle.active .icon-close { display: block; }
+
+  .viewport {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
   .sidebar {
-    border-left: none;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(360px, 85vw);
+    z-index: 1000;
+    border-left: 1px solid rgba(255, 255, 255, 0.08);
+    transform: translateX(100%);
+    transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: -4px 0 24px rgba(0, 0, 0, 0.5);
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  /* Backdrop overlay when sidebar is open */
+  .sidebar-backdrop {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 999;
+    background: rgba(0, 0, 0, 0.5);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .sidebar-backdrop.visible {
+    display: block;
   }
 }


### PR DESCRIPTION
On mobile viewports (<=960px), the sidebar now slides in as an overlay from the right instead of stacking below the canvas. The canvas takes the full viewport. A toggle button (hamburger/close) appears in the top-right corner to open/close the sidebar, with a backdrop overlay for dismissal.

https://claude.ai/code/session_01Fr9ZjjxxLWAuDzPNccUEkm

<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->
