### PR TITLE
Fix WASM 404s: disable Vercel auto-deploy, build via CI for all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [feat/rapier-destruction]
   pull_request:
 
 # ── Change this to your default/production branch ──────────
@@ -75,7 +74,9 @@ jobs:
   deploy-preview:
     name: Deploy Preview
     needs: build-and-test
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && github.ref != format('refs/heads/{0}', vars.PRODUCTION_BRANCH || 'feat/rapier-destruction'))
     runs-on: ubuntu-latest
     environment:
       name: preview
@@ -113,7 +114,7 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Comment preview URL on PR
-        if: steps.deploy.outputs.url
+        if: github.event_name == 'pull_request' && steps.deploy.outputs.url
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: demo-site
-          path: .
+          path: blast/
 
       - name: Install root dependencies (for vendor libs)
         run: npm install
@@ -161,7 +161,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: demo-site
-          path: .
+          path: blast/
 
       - name: Install root dependencies (for vendor libs)
         run: npm install

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,9 @@
   "buildCommand": "bash scripts/build-demo-site.sh",
   "outputDirectory": ".vercel/output/static",
   "framework": null,
+  "git": {
+    "deploymentEnabled": false
+  },
   "headers": [
     {
       "source": "/(.*)\\.wasm",


### PR DESCRIPTION
Vercel's automatic git deployments fail because Emscripten is not available in the Vercel build environment, causing WASM files to be missing (404s).

Changes:
- vercel.json: add git.deploymentEnabled=false to prevent Vercel from auto-deploying on push (all deploys must go through CI with --prebuilt)
- ci.yml: trigger on all branch pushes (not just feat/rapier-destruction) so every branch gets a CI-built preview with proper WASM compilation
- ci.yml: deploy-preview now runs for both PRs and non-production pushes; PR comment step is conditional on pull_request events only

https://claude.ai/code/session_01DT9Y6DXfq93wWed3kan3yy

<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->
