### PR TITLE
Fix Reset Bridge button to preserve UI settings instead of reloading page

### DIFF
--- a/blast/js_stress_example/.gitignore
+++ b/blast/js_stress_example/.gitignore
@@ -1,5 +1,6 @@
 dist/
 node_modules/
+vendor/
 
 stress_solver.cjs
 stress_solver.wasm

--- a/blast/js_stress_example/bridge/controls.js
+++ b/blast/js_stress_example/bridge/controls.js
@@ -5,7 +5,15 @@ import { HUD, pushEvent, controlsUI, updateStrengthUI, updateIterationsUI, updat
 import { spawnProjectile } from './spawning.js';
 import { scaleStressLimits, clamp, toleranceFromExponent } from './utils.js';
 
-export function setupControls(world, bridge) {
+/**
+ * @param {object} state   – mutable { world, bridge } container shared with the animation loop
+ * @param {THREE.Scene} scene
+ * @param {object} stressRuntime
+ * @param {function} resetFn – called as resetFn(scene, stressRuntime)
+ */
+export function setupControls(state, scene, stressRuntime, resetFn) {
+  const { world, bridge } = state;
+
   if (!bridge.solverSettings) {
     bridge.solverSettings = {
       maxIterations: SOLVER_DEFAULTS.maxIterations,
@@ -17,8 +25,8 @@ export function setupControls(world, bridge) {
     controlsUI.gravitySlider.value = GRAVITY_DEFAULT.toString();
     controlsUI.gravitySlider.addEventListener('input', (event) => {
       const value = parseFloat(event.target.value);
-      world.gravity = new RAPIER.Vector3(0, value, 0);
-      bridge.activeGravity = value;
+      state.world.gravity = new RAPIER.Vector3(0, value, 0);
+      state.bridge.activeGravity = value;
       if (HUD.gravityValue) {
         HUD.gravityValue.textContent = value.toFixed(2);
       }
@@ -27,12 +35,12 @@ export function setupControls(world, bridge) {
   }
   if (controlsUI.fireButton) {
     controlsUI.fireButton.addEventListener('click', () => {
-      spawnProjectile(world, bridge);
+      spawnProjectile(state.world, state.bridge);
     });
   }
   if (controlsUI.resetButton) {
     controlsUI.resetButton.addEventListener('click', () => {
-      window.location.reload();
+      resetFn(scene, stressRuntime);
     });
   }
   if (controlsUI.strengthSlider) {
@@ -40,9 +48,9 @@ export function setupControls(world, bridge) {
     updateStrengthUI(bridge.strengthScale);
     controlsUI.strengthSlider.addEventListener('input', (event) => {
       const value = parseFloat(event.target.value);
-      bridge.strengthScale = clamp(Number.isFinite(value) ? value : STRENGTH_DEFAULT, 0, 5);
-      bridge.limits = new bridge.limitsCtor(scaleStressLimits(bridge.baseLimits, bridge.strengthScale));
-      const display = updateStrengthUI(bridge.strengthScale);
+      state.bridge.strengthScale = clamp(Number.isFinite(value) ? value : STRENGTH_DEFAULT, 0, 5);
+      state.bridge.limits = new state.bridge.limitsCtor(scaleStressLimits(state.bridge.baseLimits, state.bridge.strengthScale));
+      const display = updateStrengthUI(state.bridge.strengthScale);
       pushEvent(`Material strength scaled to ${display}`);
     });
   }
@@ -51,13 +59,13 @@ export function setupControls(world, bridge) {
     updateIterationsUI(bridge.solverSettings.maxIterations);
     controlsUI.iterSlider.addEventListener('input', (event) => {
       const value = parseInt(event.target.value, 10);
-      bridge.solverSettings.maxIterations = clamp(value, 1, 256);
-      bridge.stressProcessor.setSolverParams({
-        maxIterations: bridge.solverSettings.maxIterations,
-        tolerance: toleranceFromExponent(bridge.solverSettings.toleranceExponent)
+      state.bridge.solverSettings.maxIterations = clamp(value, 1, 256);
+      state.bridge.stressProcessor.setSolverParams({
+        maxIterations: state.bridge.solverSettings.maxIterations,
+        tolerance: toleranceFromExponent(state.bridge.solverSettings.toleranceExponent)
       });
-      updateIterationsUI(bridge.solverSettings.maxIterations);
-      pushEvent(`Solver iterations set to ${bridge.solverSettings.maxIterations}`);
+      updateIterationsUI(state.bridge.solverSettings.maxIterations);
+      pushEvent(`Solver iterations set to ${state.bridge.solverSettings.maxIterations}`);
     });
   }
   if (controlsUI.toleranceSlider) {
@@ -65,10 +73,10 @@ export function setupControls(world, bridge) {
     updateToleranceUI(bridge.solverSettings.toleranceExponent);
     controlsUI.toleranceSlider.addEventListener('input', (event) => {
       const exponent = clamp(parseFloat(event.target.value), -12, -2);
-      bridge.solverSettings.toleranceExponent = exponent;
-      bridge.stressProcessor.setSolverParams({
+      state.bridge.solverSettings.toleranceExponent = exponent;
+      state.bridge.stressProcessor.setSolverParams({
         tolerance: toleranceFromExponent(exponent),
-        maxIterations: bridge.solverSettings.maxIterations
+        maxIterations: state.bridge.solverSettings.maxIterations
       });
       updateToleranceUI(exponent);
       pushEvent(`Solver tolerance set to 1.0e${exponent.toFixed(2)}`);
@@ -77,7 +85,7 @@ export function setupControls(world, bridge) {
   if (controlsUI.debugToggle && bridge.debugRenderer) {
     setDebugToggleLabel(bridge.debugRenderer.enabled);
     controlsUI.debugToggle.addEventListener('click', () => {
-      const enabled = bridge.debugRenderer.toggle();
+      const enabled = state.bridge.debugRenderer.toggle();
       setDebugToggleLabel(enabled);
     });
   }

--- a/blast/js_stress_example/bridge/index.js
+++ b/blast/js_stress_example/bridge/index.js
@@ -8,32 +8,142 @@ import { setupControls } from './controls.js';
 import { updateBridge } from './simulation.js';
 import { pushEvent } from './ui.js';
 import { GRAVITY_DEFAULT } from './constants.js';
-import { toleranceFromExponent } from './utils.js';
+import { toleranceFromExponent, scaleStressLimits } from './utils.js';
+
+// Mutable state referenced by the animation loop.
+const state = { world: null, bridge: null };
+
+/**
+ * Tear down the current physics world and bridge, then rebuild using the
+ * current UI slider values.  Three.js scene, renderer, camera and orbit
+ * controls are reused – only the physics bodies and bridge meshes are replaced.
+ */
+function resetScene(scene, stressRuntime) {
+  const oldBridge = state.bridge;
+  const oldWorld = state.world;
+
+  // --- read current slider values so they survive the reset ----------------
+  const gravitySlider = document.getElementById('gravity-slider');
+  const strengthSlider = document.getElementById('strength-slider');
+  const iterSlider = document.getElementById('iter-slider');
+  const toleranceSlider = document.getElementById('tolerance-slider');
+
+  const gravity = gravitySlider ? parseFloat(gravitySlider.value) : GRAVITY_DEFAULT;
+  const strengthScale = strengthSlider ? parseFloat(strengthSlider.value) : oldBridge?.strengthScale;
+  const maxIterations = iterSlider ? parseInt(iterSlider.value, 10) : oldBridge?.solverSettings?.maxIterations;
+  const toleranceExponent = toleranceSlider ? parseFloat(toleranceSlider.value) : oldBridge?.solverSettings?.toleranceExponent;
+
+  // --- tear down old bridge ------------------------------------------------
+  if (oldBridge) {
+    // Remove projectile meshes & bodies
+    (oldBridge.projectiles || []).forEach((p) => {
+      p.mesh?.removeFromParent();
+      const body = oldWorld?.getRigidBody(p.bodyHandle);
+      if (body) oldWorld.removeRigidBody(body);
+    });
+
+    // Remove load vehicle
+    if (oldBridge.loadVehicle) {
+      oldBridge.loadVehicle.mesh?.removeFromParent();
+      const body = oldWorld?.getRigidBody(oldBridge.loadVehicle.bodyHandle);
+      if (body) oldWorld.removeRigidBody(body);
+    }
+
+    // Remove bridge chunk meshes
+    (oldBridge.chunks || []).forEach((chunk) => {
+      if (chunk.mesh) {
+        chunk.mesh.removeFromParent();
+        chunk.mesh.geometry?.dispose();
+        chunk.mesh.material?.dispose();
+      }
+    });
+
+    // Remove split body meshes if any
+    (oldBridge.splitBodies || []).forEach((handle) => {
+      const body = oldWorld?.getRigidBody(handle);
+      if (body) oldWorld.removeRigidBody(body);
+    });
+
+    // Dispose debug renderer
+    if (oldBridge.debugRenderer) {
+      oldBridge.debugRenderer.dispose();
+    }
+  }
+
+  // Remove any remaining non-light objects from the scene (ground, etc.)
+  const toRemove = [];
+  scene.traverse((obj) => {
+    if (obj !== scene && !(obj instanceof THREE.Light)) {
+      toRemove.push(obj);
+    }
+  });
+  toRemove.forEach((obj) => {
+    obj.removeFromParent();
+    if (obj.geometry) obj.geometry.dispose();
+    if (obj.material) obj.material.dispose();
+  });
+
+  // Free old Rapier world
+  if (oldWorld) {
+    oldWorld.free();
+  }
+
+  // --- build fresh scene with current settings -----------------------------
+  const world = new RAPIER.World(new RAPIER.Vector3(0, gravity, 0));
+  const bridge = buildBridge(scene, world, stressRuntime);
+
+  // Apply current UI values
+  bridge.activeGravity = gravity;
+  if (strengthScale != null) {
+    bridge.strengthScale = strengthScale;
+    bridge.limits = new bridge.limitsCtor(
+      scaleStressLimits(bridge.baseLimits, bridge.strengthScale)
+    );
+  }
+  if (maxIterations != null) {
+    bridge.solverSettings.maxIterations = maxIterations;
+  }
+  if (toleranceExponent != null) {
+    bridge.solverSettings.toleranceExponent = toleranceExponent;
+  }
+  bridge.stressProcessor.setSolverParams({
+    maxIterations: bridge.solverSettings.maxIterations,
+    tolerance: toleranceFromExponent(bridge.solverSettings.toleranceExponent)
+  });
+
+  spawnLoadVehicle(world, bridge);
+
+  state.world = world;
+  state.bridge = bridge;
+
+  pushEvent('Bridge reset with current settings');
+}
 
 async function init() {
   await RAPIER.init();
   const stressRuntime = await loadStressSolver();
 
-  const world = new RAPIER.World(new RAPIER.Vector3(0, GRAVITY_DEFAULT, 0));
   const { scene, renderer, camera, controls } = initThree();
-  const bridge = buildBridge(scene, world, stressRuntime);
 
-  spawnLoadVehicle(world, bridge);
-  setupControls(world, bridge);
+  state.world = new RAPIER.World(new RAPIER.Vector3(0, GRAVITY_DEFAULT, 0));
+  state.bridge = buildBridge(scene, state.world, stressRuntime);
 
-  bridge.stressProcessor.setSolverParams({
-    maxIterations: bridge.solverSettings.maxIterations,
-    tolerance: toleranceFromExponent(bridge.solverSettings.toleranceExponent)
+  spawnLoadVehicle(state.world, state.bridge);
+  setupControls(state, scene, stressRuntime, resetScene);
+
+  state.bridge.stressProcessor.setSolverParams({
+    maxIterations: state.bridge.solverSettings.maxIterations,
+    tolerance: toleranceFromExponent(state.bridge.solverSettings.toleranceExponent)
   });
 
   const clock = new THREE.Clock();
 
   function loop() {
     const delta = clock.getDelta();
-    updateBridge(world, bridge, delta);
-    world.step();
-    if (bridge.debugRenderer?.enabled) {
-      bridge.debugRenderer.update();
+    updateBridge(state.world, state.bridge, delta);
+    state.world.step();
+    if (state.bridge.debugRenderer?.enabled) {
+      state.bridge.debugRenderer.update();
     }
     controls.update();
     renderer.render(scene, camera);


### PR DESCRIPTION
The Reset Bridge button previously called window.location.reload(), which discarded all user-configured settings (gravity, material strength, solver iterations, tolerance). Now it tears down the physics world and bridge meshes in-place, then rebuilds the scene using the current slider values.

https://claude.ai/code/session_01CQGLnUCMzmJm1hTNxQ5iYJ

<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->
