### PR TITLE
Add comprehensive runtime performance stats to demo pages

### DIFF
--- a/blast/js_stress_example/dist/tower-collapse.js
+++ b/blast/js_stress_example/dist/tower-collapse.js
@@ -1,57 +1,60 @@
-import * as THREE from "three";
-import { OrbitControls } from "three/addons/controls/OrbitControls.js";
-import { buildDestructibleCore } from "blast-stress-solver/rapier";
-import {
-  createDestructibleThreeBundle,
-  RapierDebugRenderer,
-  applyAutoBondingToScenario
-} from "blast-stress-solver/three";
-import { buildTowerScenario } from "blast-stress-solver/scenarios";
+/**
+ * Tower Collapse Demo
+ *
+ * Showcases the high-level blast-stress-solver/rapier and blast-stress-solver/three
+ * APIs with a tall tower that collapses under its own weight or projectile impacts.
+ *
+ * Click the viewport to launch projectiles at the tower.
+ */
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import Stats from 'three/addons/libs/stats.module.js';
+import { buildDestructibleCore } from 'blast-stress-solver/rapier';
+import { createDestructibleThreeBundle, RapierDebugRenderer, applyAutoBondingToScenario, } from 'blast-stress-solver/three';
+import { buildTowerScenario } from 'blast-stress-solver/scenarios';
+// ── Config ────────────────────────────────────────────────────
 const CONFIG = {
-  tower: {
-    side: 4,
-    stories: 16,
-    spacing: { x: 0.42, y: 0.42, z: 0.42 },
-    totalMass: 5e3,
-    areaScale: 0.05,
-    addDiagonals: true,
-    diagScale: 0.55,
-    normalizeAreas: true
-  },
-  projectile: {
-    radius: 0.35,
-    mass: 15e3,
-    speed: 22
-  },
-  solver: {
-    gravity: -9.81,
-    materialScale: 1e8
-  },
-  autoBonds: false
+    tower: {
+        side: 4,
+        stories: 16,
+        spacing: { x: 0.42, y: 0.42, z: 0.42 },
+        totalMass: 5000,
+        areaScale: 0.05,
+        addDiagonals: true,
+        diagScale: 0.55,
+        normalizeAreas: true,
+    },
+    projectile: {
+        radius: 0.35,
+        mass: 15000,
+        speed: 22,
+    },
+    solver: {
+        gravity: -9.81,
+        materialScale: 1e8,
+    },
+    autoBonds: false,
 };
-const canvas = document.getElementById("demo-canvas");
+// ── Three.js setup ────────────────────────────────────────────
+const canvas = document.getElementById('demo-canvas');
 const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
 renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
 renderer.shadowMap.enabled = true;
 renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(724501);
-scene.fog = new THREE.FogExp2(724501, 0.015);
-const camera = new THREE.PerspectiveCamera(
-  55,
-  canvas.clientWidth / canvas.clientHeight,
-  0.1,
-  200
-);
+scene.background = new THREE.Color(0x0b0e15);
+scene.fog = new THREE.FogExp2(0x0b0e15, 0.015);
+const camera = new THREE.PerspectiveCamera(55, canvas.clientWidth / canvas.clientHeight, 0.1, 200);
 camera.position.set(6, 5, 12);
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.target.set(0, 2.5, 0);
 controls.enableDamping = true;
 controls.dampingFactor = 0.08;
 controls.update();
-scene.add(new THREE.AmbientLight(16777215, 0.35));
-const dirLight = new THREE.DirectionalLight(16772829, 1);
+// Lights
+scene.add(new THREE.AmbientLight(0xffffff, 0.35));
+const dirLight = new THREE.DirectionalLight(0xffeedd, 1.0);
 dirLight.position.set(10, 18, 8);
 dirLight.castShadow = true;
 dirLight.shadow.mapSize.set(2048, 2048);
@@ -60,188 +63,229 @@ dirLight.shadow.camera.right = 12;
 dirLight.shadow.camera.top = 16;
 dirLight.shadow.camera.bottom = -4;
 scene.add(dirLight);
+// Ground
 const groundGeo = new THREE.PlaneGeometry(60, 60);
 const groundMat = new THREE.MeshStandardMaterial({
-  color: 1711663,
-  roughness: 0.85,
-  metalness: 0.1
+    color: 0x1a1e2f,
+    roughness: 0.85,
+    metalness: 0.1,
 });
 const groundMesh = new THREE.Mesh(groundGeo, groundMat);
 groundMesh.rotation.x = -Math.PI / 2;
 groundMesh.position.y = -0.4;
 groundMesh.receiveShadow = true;
 scene.add(groundMesh);
-function updateStatus(core) {
-  const el = (id) => document.getElementById(id);
-  el("stat-bodies").textContent = String(core.getRigidBodyCount());
-  el("stat-bonds").textContent = String(core.getActiveBondsCount());
-  el("stat-projectiles").textContent = String(core.projectiles.length);
-  const active = core.chunks.filter((c) => c.active).length;
-  const detached = core.chunks.filter((c) => c.detached).length;
-  el("stat-chunks").textContent = `${active} / ${detached} detached`;
+// ── Stats panel (FPS / MS / MB) ───────────────────────────────
+const stats = new Stats();
+stats.dom.style.position = 'absolute';
+stats.dom.style.top = '0';
+stats.dom.style.left = '0';
+document.querySelector('.viewport')?.appendChild(stats.dom);
+// ── Perf tracking ─────────────────────────────────────────────
+let _physicsMs = 0;
+let _renderMs = 0;
+const EMA = 0.12; // exponential moving-average smoothing factor
+function updatePerfStats() {
+    const el = (id) => document.getElementById(id);
+    el('stat-physics-ms').textContent = _physicsMs.toFixed(1) + ' ms';
+    el('stat-render-ms').textContent = _renderMs.toFixed(1) + ' ms';
+    el('stat-draw-calls').textContent = String(renderer.info.render.calls);
+    el('stat-triangles').textContent = renderer.info.render.triangles.toLocaleString();
 }
+// ── Status HUD ────────────────────────────────────────────────
+function updateStatus(core) {
+    const el = (id) => document.getElementById(id);
+    el('stat-bodies').textContent = String(core.getRigidBodyCount());
+    el('stat-bonds').textContent = String(core.getActiveBondsCount());
+    el('stat-projectiles').textContent = String(core.projectiles.length);
+    const active = core.chunks.filter((c) => c.active).length;
+    const detached = core.chunks.filter((c) => c.detached).length;
+    el('stat-chunks').textContent = `${active} / ${detached} detached`;
+}
+// ── Main ──────────────────────────────────────────────────────
 let coreRef = null;
 let visualsRef = null;
 let rapierDebug = null;
 let showDebug = false;
 async function initScene() {
-  let scenario = buildTowerScenario(CONFIG.tower);
-  const sp = scenario.spacing;
-  const fragmentGeometries = scenario.nodes.map(
-    () => new THREE.BoxGeometry(sp.x, sp.y, sp.z)
-  );
-  scenario = {
-    ...scenario,
-    parameters: { ...scenario.parameters, fragmentGeometries }
-  };
-  if (CONFIG.autoBonds) {
-    scenario = await applyAutoBondingToScenario(scenario, { mode: "average", maxSeparation: 0.01 });
-  }
-  console.log(
-    `Tower: ${scenario.nodes.length} nodes, ${scenario.bonds.length} bonds` + (CONFIG.autoBonds ? " (auto-bonded)" : " (manual)")
-  );
-  const core = await buildDestructibleCore({
-    scenario,
-    gravity: CONFIG.solver.gravity,
-    materialScale: CONFIG.solver.materialScale,
-    debrisCollisionMode: "noDebrisPairs",
-    damage: {
-      enabled: false
-    },
-    debrisCleanup: {
-      mode: "always",
-      debrisTtlMs: 1e4,
-      maxCollidersForDebris: 2
-    },
-    smallBodyDamping: {
-      mode: "always",
-      colliderCountThreshold: 3,
-      minLinearDamping: 2,
-      minAngularDamping: 2
+    let scenario = buildTowerScenario(CONFIG.tower);
+    // Attach fragment geometries for auto-bonding support
+    const sp = scenario.spacing;
+    const fragmentGeometries = scenario.nodes.map(() => new THREE.BoxGeometry(sp.x, sp.y, sp.z));
+    scenario = {
+        ...scenario,
+        parameters: { ...scenario.parameters, fragmentGeometries },
+    };
+    // Auto-bonding: replace manual grid bonds with geometry-derived bonds
+    if (CONFIG.autoBonds) {
+        scenario = await applyAutoBondingToScenario(scenario, { mode: 'average', maxSeparation: 0.01 });
     }
-  });
-  const group = new THREE.Group();
-  scene.add(group);
-  const visuals = createDestructibleThreeBundle({
-    core,
-    scenario,
-    root: group,
-    useBatchedMesh: true,
-    batchedMeshOptions: { enableBVH: false, bvhMargin: 5 },
-    includeDebugLines: true
-  });
-  rapierDebug?.dispose();
-  rapierDebug = new RapierDebugRenderer(scene, core.world, { enabled: showDebug });
-  coreRef = core;
-  visualsRef = visuals;
+    console.log(`Tower: ${scenario.nodes.length} nodes, ${scenario.bonds.length} bonds` +
+        (CONFIG.autoBonds ? ' (auto-bonded)' : ' (manual)'));
+    const core = await buildDestructibleCore({
+        scenario,
+        gravity: CONFIG.solver.gravity,
+        materialScale: CONFIG.solver.materialScale,
+        debrisCollisionMode: 'noDebrisPairs',
+        damage: {
+            enabled: false,
+        },
+        debrisCleanup: {
+            mode: 'always',
+            debrisTtlMs: 10000,
+            maxCollidersForDebris: 2,
+        },
+        smallBodyDamping: {
+            mode: 'always',
+            colliderCountThreshold: 3,
+            minLinearDamping: 2,
+            minAngularDamping: 2,
+        },
+    });
+    const group = new THREE.Group();
+    scene.add(group);
+    const visuals = createDestructibleThreeBundle({
+        core,
+        scenario,
+        root: group,
+        useBatchedMesh: true,
+        batchedMeshOptions: { enableBVH: false, bvhMargin: 5 },
+        includeDebugLines: true,
+    });
+    // Rapier collider wireframe overlay
+    rapierDebug?.dispose();
+    rapierDebug = new RapierDebugRenderer(scene, core.world, { enabled: showDebug });
+    coreRef = core;
+    visualsRef = visuals;
 }
+// ── Projectile shooting ───────────────────────────────────────
 function shootProjectile(ndcX, ndcY) {
-  const core = coreRef;
-  if (!core) return;
-  const raycaster = new THREE.Raycaster();
-  raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
-  const dir = raycaster.ray.direction.clone().normalize();
-  core.enqueueProjectile({
-    position: {
-      x: camera.position.x,
-      y: camera.position.y,
-      z: camera.position.z
-    },
-    velocity: {
-      x: dir.x * CONFIG.projectile.speed,
-      y: dir.y * CONFIG.projectile.speed,
-      z: dir.z * CONFIG.projectile.speed
-    },
-    radius: CONFIG.projectile.radius,
-    mass: CONFIG.projectile.mass,
-    ttl: 8e3
-  });
+    const core = coreRef;
+    if (!core)
+        return;
+    const raycaster = new THREE.Raycaster();
+    raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
+    const dir = raycaster.ray.direction.clone().normalize();
+    core.enqueueProjectile({
+        position: {
+            x: camera.position.x,
+            y: camera.position.y,
+            z: camera.position.z,
+        },
+        velocity: {
+            x: dir.x * CONFIG.projectile.speed,
+            y: dir.y * CONFIG.projectile.speed,
+            z: dir.z * CONFIG.projectile.speed,
+        },
+        radius: CONFIG.projectile.radius,
+        mass: CONFIG.projectile.mass,
+        ttl: 8000,
+    });
 }
-canvas.addEventListener("click", (e) => {
-  const rect = canvas.getBoundingClientRect();
-  const ndcX = (e.clientX - rect.left) / rect.width * 2 - 1;
-  const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
-  shootProjectile(ndcX, ndcY);
+canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const ndcX = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+    shootProjectile(ndcX, ndcY);
 });
-document.getElementById("btn-reset")?.addEventListener("click", async () => {
-  visualsRef?.dispose();
-  coreRef?.dispose();
-  coreRef = null;
-  visualsRef = null;
-  await initScene();
+// ── UI wiring ─────────────────────────────────────────────────
+document.getElementById('btn-reset')?.addEventListener('click', async () => {
+    visualsRef?.dispose();
+    coreRef?.dispose();
+    coreRef = null;
+    visualsRef = null;
+    await initScene();
 });
-document.getElementById("btn-debug")?.addEventListener("click", () => {
-  showDebug = !showDebug;
-  rapierDebug?.setEnabled(showDebug);
-  const btn = document.getElementById("btn-debug");
-  btn.textContent = showDebug ? "\u25C8 Hide Debug" : "\u25C7 Show Debug";
+document.getElementById('btn-debug')?.addEventListener('click', () => {
+    showDebug = !showDebug;
+    rapierDebug?.setEnabled(showDebug);
+    const btn = document.getElementById('btn-debug');
+    btn.textContent = showDebug ? '◈ Hide Debug' : '◇ Show Debug';
 });
+// Config sliders
 function bindSlider(id, obj, key, fmt) {
-  const slider = document.getElementById(id);
-  const display = document.getElementById(id + "-value");
-  if (!slider) return;
-  slider.value = String(obj[key]);
-  if (display) display.textContent = fmt ? fmt(obj[key]) : String(obj[key]);
-  slider.addEventListener("input", () => {
-    const v = parseFloat(slider.value);
-    obj[key] = v;
-    if (display) display.textContent = fmt ? fmt(v) : String(v);
-  });
-}
-bindSlider("cfg-side", CONFIG.tower, "side");
-bindSlider("cfg-stories", CONFIG.tower, "stories");
-bindSlider("cfg-area-scale", CONFIG.tower, "areaScale", (v) => v.toFixed(3));
-bindSlider("cfg-total-mass", CONFIG.tower, "totalMass", (v) => v.toLocaleString());
-bindSlider("cfg-proj-radius", CONFIG.projectile, "radius", (v) => v.toFixed(2));
-bindSlider("cfg-proj-mass", CONFIG.projectile, "mass", (v) => v.toLocaleString());
-bindSlider("cfg-proj-speed", CONFIG.projectile, "speed", (v) => v.toFixed(0));
-bindSlider("cfg-gravity", CONFIG.solver, "gravity", (v) => v.toFixed(1));
-{
-  const slider = document.getElementById("cfg-material");
-  const display = document.getElementById("cfg-material-value");
-  if (slider) {
-    const exp = Math.log10(CONFIG.solver.materialScale);
-    slider.value = String(exp);
-    if (display) display.textContent = `1e${exp.toFixed(0)}`;
-    slider.addEventListener("input", () => {
-      const exp2 = parseFloat(slider.value);
-      CONFIG.solver.materialScale = Math.pow(10, exp2);
-      if (display) display.textContent = `1e${exp2.toFixed(1)}`;
+    const slider = document.getElementById(id);
+    const display = document.getElementById(id + '-value');
+    if (!slider)
+        return;
+    slider.value = String(obj[key]);
+    if (display)
+        display.textContent = fmt ? fmt(obj[key]) : String(obj[key]);
+    slider.addEventListener('input', () => {
+        const v = parseFloat(slider.value);
+        obj[key] = v;
+        if (display)
+            display.textContent = fmt ? fmt(v) : String(v);
     });
-  }
 }
+bindSlider('cfg-side', CONFIG.tower, 'side');
+bindSlider('cfg-stories', CONFIG.tower, 'stories');
+bindSlider('cfg-area-scale', CONFIG.tower, 'areaScale', (v) => v.toFixed(3));
+bindSlider('cfg-total-mass', CONFIG.tower, 'totalMass', (v) => v.toLocaleString());
+bindSlider('cfg-proj-radius', CONFIG.projectile, 'radius', (v) => v.toFixed(2));
+bindSlider('cfg-proj-mass', CONFIG.projectile, 'mass', (v) => v.toLocaleString());
+bindSlider('cfg-proj-speed', CONFIG.projectile, 'speed', (v) => v.toFixed(0));
+bindSlider('cfg-gravity', CONFIG.solver, 'gravity', (v) => v.toFixed(1));
+// Material scale uses a log slider: slider value is the exponent (log10)
 {
-  const checkbox = document.getElementById("cfg-auto-bonds");
-  if (checkbox) {
-    checkbox.checked = CONFIG.autoBonds;
-    checkbox.addEventListener("change", () => {
-      CONFIG.autoBonds = checkbox.checked;
-    });
-  }
+    const slider = document.getElementById('cfg-material');
+    const display = document.getElementById('cfg-material-value');
+    if (slider) {
+        const exp = Math.log10(CONFIG.solver.materialScale);
+        slider.value = String(exp);
+        if (display)
+            display.textContent = `1e${exp.toFixed(0)}`;
+        slider.addEventListener('input', () => {
+            const exp = parseFloat(slider.value);
+            CONFIG.solver.materialScale = Math.pow(10, exp);
+            if (display)
+                display.textContent = `1e${exp.toFixed(1)}`;
+        });
+    }
 }
+// Auto-bonds toggle
+{
+    const checkbox = document.getElementById('cfg-auto-bonds');
+    if (checkbox) {
+        checkbox.checked = CONFIG.autoBonds;
+        checkbox.addEventListener('change', () => {
+            CONFIG.autoBonds = checkbox.checked;
+        });
+    }
+}
+// ── Render loop ───────────────────────────────────────────────
 const clock = new THREE.Clock();
 function loop() {
-  requestAnimationFrame(loop);
-  const dt = Math.min(clock.getDelta(), 1 / 30);
-  controls.update();
-  if (coreRef && visualsRef) {
-    coreRef.step(dt);
-    visualsRef.update({
-      debug: showDebug,
-      updateBVH: false,
-      updateProjectiles: true
-    });
-    rapierDebug?.update();
-    updateStatus(coreRef);
-  }
-  renderer.render(scene, camera);
+    requestAnimationFrame(loop);
+    stats.begin();
+    const dt = Math.min(clock.getDelta(), 1 / 30);
+    controls.update();
+    if (coreRef && visualsRef) {
+        const t0 = performance.now();
+        coreRef.step(dt);
+        _physicsMs += ((performance.now() - t0) - _physicsMs) * EMA;
+        visualsRef.update({
+            debug: showDebug,
+            updateBVH: false,
+            updateProjectiles: true,
+        });
+        rapierDebug?.update();
+        updateStatus(coreRef);
+    }
+    const t1 = performance.now();
+    renderer.render(scene, camera);
+    _renderMs += ((performance.now() - t1) - _renderMs) * EMA;
+    updatePerfStats();
+    stats.end();
 }
+// ── Resize ────────────────────────────────────────────────────
 function onResize() {
-  const w = canvas.clientWidth;
-  const h = canvas.clientHeight;
-  renderer.setSize(w, h, false);
-  camera.aspect = w / h;
-  camera.updateProjectionMatrix();
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h;
+    camera.updateProjectionMatrix();
 }
-window.addEventListener("resize", onResize);
+window.addEventListener('resize', onResize);
+// ── Boot ──────────────────────────────────────────────────────
 initScene().then(() => loop());

--- a/blast/js_stress_example/dist/wall-demolition.js
+++ b/blast/js_stress_example/dist/wall-demolition.js
@@ -1,61 +1,64 @@
-import * as THREE from "three";
-import { OrbitControls } from "three/addons/controls/OrbitControls.js";
-import { buildDestructibleCore } from "blast-stress-solver/rapier";
-import {
-  createDestructibleThreeBundle,
-  RapierDebugRenderer,
-  applyAutoBondingToScenario
-} from "blast-stress-solver/three";
-import { buildWallScenario } from "blast-stress-solver/scenarios";
+/**
+ * Wall Demolition Demo
+ *
+ * Showcases the high-level blast-stress-solver/rapier and blast-stress-solver/three
+ * APIs: buildDestructibleCore + createDestructibleThreeBundle.
+ *
+ * Click the viewport to launch projectiles at a destructible brick wall.
+ */
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import Stats from 'three/addons/libs/stats.module.js';
+import { buildDestructibleCore } from 'blast-stress-solver/rapier';
+import { createDestructibleThreeBundle, RapierDebugRenderer, applyAutoBondingToScenario, } from 'blast-stress-solver/three';
+import { buildWallScenario } from 'blast-stress-solver/scenarios';
+// ── Config ────────────────────────────────────────────────────
 const CONFIG = {
-  wall: {
-    span: 6,
-    height: 3,
-    thickness: 0.32,
-    spanSegments: 12,
-    heightSegments: 6,
-    layers: 1,
-    deckMass: 1e4,
-    areaScale: 0.05,
-    addDiagonals: false,
-    diagScale: 0.75,
-    normalizeAreas: true
-  },
-  projectile: {
-    radius: 0.35,
-    mass: 15e3,
-    speed: 20
-  },
-  solver: {
-    gravity: -9.81,
-    materialScale: 1e8
-  },
-  autoBonds: false
+    wall: {
+        span: 6.0,
+        height: 3.0,
+        thickness: 0.32,
+        spanSegments: 12,
+        heightSegments: 6,
+        layers: 1,
+        deckMass: 10000,
+        areaScale: 0.05,
+        addDiagonals: false,
+        diagScale: 0.75,
+        normalizeAreas: true,
+    },
+    projectile: {
+        radius: 0.35,
+        mass: 15000,
+        speed: 20,
+    },
+    solver: {
+        gravity: -9.81,
+        materialScale: 1e8,
+    },
+    autoBonds: false,
 };
-const canvas = document.getElementById("demo-canvas");
+// ── Three.js setup ────────────────────────────────────────────
+const canvas = document.getElementById('demo-canvas');
 const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
 renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
 renderer.shadowMap.enabled = true;
 renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(658707);
-scene.fog = new THREE.FogExp2(658707, 0.02);
-const camera = new THREE.PerspectiveCamera(
-  55,
-  canvas.clientWidth / canvas.clientHeight,
-  0.1,
-  200
-);
+scene.background = new THREE.Color(0x0a0d13);
+scene.fog = new THREE.FogExp2(0x0a0d13, 0.02);
+const camera = new THREE.PerspectiveCamera(55, canvas.clientWidth / canvas.clientHeight, 0.1, 200);
 camera.position.set(0, 3, 12);
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.target.set(0, 1.5, 0);
 controls.enableDamping = true;
 controls.dampingFactor = 0.08;
 controls.update();
-const ambientLight = new THREE.AmbientLight(16777215, 0.4);
+// Lights
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.4);
 scene.add(ambientLight);
-const dirLight = new THREE.DirectionalLight(16772829, 1);
+const dirLight = new THREE.DirectionalLight(0xffeedd, 1.0);
 dirLight.position.set(8, 14, 10);
 dirLight.castShadow = true;
 dirLight.shadow.mapSize.set(2048, 2048);
@@ -64,182 +67,226 @@ dirLight.shadow.camera.right = 15;
 dirLight.shadow.camera.top = 15;
 dirLight.shadow.camera.bottom = -5;
 scene.add(dirLight);
+// Ground plane
 const groundGeo = new THREE.PlaneGeometry(60, 60);
 const groundMat = new THREE.MeshStandardMaterial({
-  color: 1711663,
-  roughness: 0.85,
-  metalness: 0.1
+    color: 0x1a1e2f,
+    roughness: 0.85,
+    metalness: 0.1,
 });
 const groundMesh = new THREE.Mesh(groundGeo, groundMat);
 groundMesh.rotation.x = -Math.PI / 2;
 groundMesh.position.y = -0.35;
 groundMesh.receiveShadow = true;
 scene.add(groundMesh);
-function updateStatus(core) {
-  const el = (id) => document.getElementById(id);
-  el("stat-bodies").textContent = String(core.getRigidBodyCount());
-  el("stat-bonds").textContent = String(core.getActiveBondsCount());
-  el("stat-projectiles").textContent = String(core.projectiles.length);
-  const active = core.chunks.filter((c) => c.active).length;
-  const detached = core.chunks.filter((c) => c.detached).length;
-  el("stat-chunks").textContent = `${active} / ${detached} detached`;
+// ── Stats panel (FPS / MS / MB) ───────────────────────────────
+const stats = new Stats();
+stats.dom.style.position = 'absolute';
+stats.dom.style.top = '0';
+stats.dom.style.left = '0';
+document.querySelector('.viewport')?.appendChild(stats.dom);
+// ── Perf tracking ─────────────────────────────────────────────
+let _physicsMs = 0;
+let _renderMs = 0;
+const EMA = 0.12; // exponential moving-average smoothing factor
+function updatePerfStats() {
+    const el = (id) => document.getElementById(id);
+    el('stat-physics-ms').textContent = _physicsMs.toFixed(1) + ' ms';
+    el('stat-render-ms').textContent = _renderMs.toFixed(1) + ' ms';
+    el('stat-draw-calls').textContent = String(renderer.info.render.calls);
+    el('stat-triangles').textContent = renderer.info.render.triangles.toLocaleString();
 }
+// ── Status HUD ────────────────────────────────────────────────
+function updateStatus(core) {
+    const el = (id) => document.getElementById(id);
+    el('stat-bodies').textContent = String(core.getRigidBodyCount());
+    el('stat-bonds').textContent = String(core.getActiveBondsCount());
+    el('stat-projectiles').textContent = String(core.projectiles.length);
+    const active = core.chunks.filter((c) => c.active).length;
+    const detached = core.chunks.filter((c) => c.detached).length;
+    el('stat-chunks').textContent = `${active} / ${detached} detached`;
+}
+// ── Main ──────────────────────────────────────────────────────
 let coreRef = null;
 let visualsRef = null;
 let rapierDebug = null;
 let showDebug = false;
 async function initScene() {
-  let scenario = buildWallScenario(CONFIG.wall);
-  const sp = scenario.spacing;
-  const fragmentGeometries = scenario.nodes.map(
-    () => new THREE.BoxGeometry(sp.x, sp.y, sp.z)
-  );
-  scenario = {
-    ...scenario,
-    parameters: { ...scenario.parameters, fragmentGeometries }
-  };
-  if (CONFIG.autoBonds) {
-    scenario = await applyAutoBondingToScenario(scenario, { mode: "average", maxSeparation: 0.01 });
-  }
-  console.log(
-    `Wall: ${scenario.nodes.length} nodes, ${scenario.bonds.length} bonds` + (CONFIG.autoBonds ? " (auto-bonded)" : " (manual)")
-  );
-  const core = await buildDestructibleCore({
-    scenario,
-    gravity: CONFIG.solver.gravity,
-    materialScale: CONFIG.solver.materialScale,
-    debrisCollisionMode: "noDebrisPairs",
-    damage: {
-      enabled: false
-    },
-    debrisCleanup: {
-      mode: "always",
-      debrisTtlMs: 8e3,
-      maxCollidersForDebris: 2
+    let scenario = buildWallScenario(CONFIG.wall);
+    // Attach fragment geometries for auto-bonding support
+    const sp = scenario.spacing;
+    const fragmentGeometries = scenario.nodes.map(() => new THREE.BoxGeometry(sp.x, sp.y, sp.z));
+    scenario = {
+        ...scenario,
+        parameters: { ...scenario.parameters, fragmentGeometries },
+    };
+    // Auto-bonding: replace manual grid bonds with geometry-derived bonds
+    if (CONFIG.autoBonds) {
+        scenario = await applyAutoBondingToScenario(scenario, { mode: 'average', maxSeparation: 0.01 });
     }
-  });
-  const group = new THREE.Group();
-  scene.add(group);
-  const visuals = createDestructibleThreeBundle({
-    core,
-    scenario,
-    root: group,
-    useBatchedMesh: true,
-    batchedMeshOptions: { enableBVH: false, bvhMargin: 5 },
-    includeDebugLines: true
-  });
-  rapierDebug?.dispose();
-  rapierDebug = new RapierDebugRenderer(scene, core.world, { enabled: showDebug });
-  coreRef = core;
-  visualsRef = visuals;
+    console.log(`Wall: ${scenario.nodes.length} nodes, ${scenario.bonds.length} bonds` +
+        (CONFIG.autoBonds ? ' (auto-bonded)' : ' (manual)'));
+    const core = await buildDestructibleCore({
+        scenario,
+        gravity: CONFIG.solver.gravity,
+        materialScale: CONFIG.solver.materialScale,
+        debrisCollisionMode: 'noDebrisPairs',
+        damage: {
+            enabled: false,
+        },
+        debrisCleanup: {
+            mode: 'always',
+            debrisTtlMs: 8000,
+            maxCollidersForDebris: 2,
+        },
+    });
+    const group = new THREE.Group();
+    scene.add(group);
+    const visuals = createDestructibleThreeBundle({
+        core,
+        scenario,
+        root: group,
+        useBatchedMesh: true,
+        batchedMeshOptions: { enableBVH: false, bvhMargin: 5 },
+        includeDebugLines: true,
+    });
+    // Rapier collider wireframe overlay
+    rapierDebug?.dispose();
+    rapierDebug = new RapierDebugRenderer(scene, core.world, { enabled: showDebug });
+    coreRef = core;
+    visualsRef = visuals;
 }
+// ── Projectile shooting ───────────────────────────────────────
 function shootProjectile(ndcX, ndcY) {
-  const core = coreRef;
-  if (!core) return;
-  const raycaster = new THREE.Raycaster();
-  raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
-  const dir = raycaster.ray.direction.clone().normalize();
-  core.enqueueProjectile({
-    position: {
-      x: camera.position.x,
-      y: camera.position.y,
-      z: camera.position.z
-    },
-    velocity: {
-      x: dir.x * CONFIG.projectile.speed,
-      y: dir.y * CONFIG.projectile.speed,
-      z: dir.z * CONFIG.projectile.speed
-    },
-    radius: CONFIG.projectile.radius,
-    mass: CONFIG.projectile.mass,
-    ttl: 6e3
-  });
+    const core = coreRef;
+    if (!core)
+        return;
+    // Ray from camera through click point
+    const raycaster = new THREE.Raycaster();
+    raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
+    const dir = raycaster.ray.direction.clone().normalize();
+    core.enqueueProjectile({
+        position: {
+            x: camera.position.x,
+            y: camera.position.y,
+            z: camera.position.z,
+        },
+        velocity: {
+            x: dir.x * CONFIG.projectile.speed,
+            y: dir.y * CONFIG.projectile.speed,
+            z: dir.z * CONFIG.projectile.speed,
+        },
+        radius: CONFIG.projectile.radius,
+        mass: CONFIG.projectile.mass,
+        ttl: 6000,
+    });
 }
-canvas.addEventListener("click", (e) => {
-  const rect = canvas.getBoundingClientRect();
-  const ndcX = (e.clientX - rect.left) / rect.width * 2 - 1;
-  const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
-  shootProjectile(ndcX, ndcY);
+canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const ndcX = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+    shootProjectile(ndcX, ndcY);
 });
-document.getElementById("btn-reset")?.addEventListener("click", async () => {
-  visualsRef?.dispose();
-  coreRef?.dispose();
-  coreRef = null;
-  visualsRef = null;
-  await initScene();
+// ── UI wiring ─────────────────────────────────────────────────
+document.getElementById('btn-reset')?.addEventListener('click', async () => {
+    // Tear down
+    visualsRef?.dispose();
+    coreRef?.dispose();
+    coreRef = null;
+    visualsRef = null;
+    // Rebuild
+    await initScene();
 });
-document.getElementById("btn-debug")?.addEventListener("click", () => {
-  showDebug = !showDebug;
-  rapierDebug?.setEnabled(showDebug);
-  const btn = document.getElementById("btn-debug");
-  btn.textContent = showDebug ? "\u25C8 Hide Debug" : "\u25C7 Show Debug";
+document.getElementById('btn-debug')?.addEventListener('click', () => {
+    showDebug = !showDebug;
+    rapierDebug?.setEnabled(showDebug);
+    const btn = document.getElementById('btn-debug');
+    btn.textContent = showDebug ? '◈ Hide Debug' : '◇ Show Debug';
 });
+// Config sliders
 function bindSlider(id, obj, key, fmt) {
-  const slider = document.getElementById(id);
-  const display = document.getElementById(id + "-value");
-  if (!slider) return;
-  slider.value = String(obj[key]);
-  if (display) display.textContent = fmt ? fmt(obj[key]) : String(obj[key]);
-  slider.addEventListener("input", () => {
-    const v = parseFloat(slider.value);
-    obj[key] = v;
-    if (display) display.textContent = fmt ? fmt(v) : String(v);
-  });
-}
-bindSlider("cfg-columns", CONFIG.wall, "spanSegments");
-bindSlider("cfg-rows", CONFIG.wall, "heightSegments");
-bindSlider("cfg-area-scale", CONFIG.wall, "areaScale", (v) => v.toFixed(3));
-bindSlider("cfg-total-mass", CONFIG.wall, "deckMass", (v) => v.toLocaleString());
-bindSlider("cfg-proj-radius", CONFIG.projectile, "radius", (v) => v.toFixed(2));
-bindSlider("cfg-proj-mass", CONFIG.projectile, "mass", (v) => v.toLocaleString());
-bindSlider("cfg-proj-speed", CONFIG.projectile, "speed", (v) => v.toFixed(0));
-bindSlider("cfg-gravity", CONFIG.solver, "gravity", (v) => v.toFixed(1));
-{
-  const slider = document.getElementById("cfg-material");
-  const display = document.getElementById("cfg-material-value");
-  if (slider) {
-    const exp = Math.log10(CONFIG.solver.materialScale);
-    slider.value = String(exp);
-    if (display) display.textContent = `1e${exp.toFixed(0)}`;
-    slider.addEventListener("input", () => {
-      const exp2 = parseFloat(slider.value);
-      CONFIG.solver.materialScale = Math.pow(10, exp2);
-      if (display) display.textContent = `1e${exp2.toFixed(1)}`;
+    const slider = document.getElementById(id);
+    const display = document.getElementById(id + '-value');
+    if (!slider)
+        return;
+    slider.value = String(obj[key]);
+    if (display)
+        display.textContent = fmt ? fmt(obj[key]) : String(obj[key]);
+    slider.addEventListener('input', () => {
+        const v = parseFloat(slider.value);
+        obj[key] = v;
+        if (display)
+            display.textContent = fmt ? fmt(v) : String(v);
     });
-  }
 }
+bindSlider('cfg-columns', CONFIG.wall, 'spanSegments');
+bindSlider('cfg-rows', CONFIG.wall, 'heightSegments');
+bindSlider('cfg-area-scale', CONFIG.wall, 'areaScale', (v) => v.toFixed(3));
+bindSlider('cfg-total-mass', CONFIG.wall, 'deckMass', (v) => v.toLocaleString());
+bindSlider('cfg-proj-radius', CONFIG.projectile, 'radius', (v) => v.toFixed(2));
+bindSlider('cfg-proj-mass', CONFIG.projectile, 'mass', (v) => v.toLocaleString());
+bindSlider('cfg-proj-speed', CONFIG.projectile, 'speed', (v) => v.toFixed(0));
+bindSlider('cfg-gravity', CONFIG.solver, 'gravity', (v) => v.toFixed(1));
+// Material scale uses a log slider: slider value is the exponent (log10)
 {
-  const checkbox = document.getElementById("cfg-auto-bonds");
-  if (checkbox) {
-    checkbox.checked = CONFIG.autoBonds;
-    checkbox.addEventListener("change", () => {
-      CONFIG.autoBonds = checkbox.checked;
-    });
-  }
+    const slider = document.getElementById('cfg-material');
+    const display = document.getElementById('cfg-material-value');
+    if (slider) {
+        const exp = Math.log10(CONFIG.solver.materialScale);
+        slider.value = String(exp);
+        if (display)
+            display.textContent = `1e${exp.toFixed(0)}`;
+        slider.addEventListener('input', () => {
+            const exp = parseFloat(slider.value);
+            CONFIG.solver.materialScale = Math.pow(10, exp);
+            if (display)
+                display.textContent = `1e${exp.toFixed(1)}`;
+        });
+    }
 }
+// Auto-bonds toggle
+{
+    const checkbox = document.getElementById('cfg-auto-bonds');
+    if (checkbox) {
+        checkbox.checked = CONFIG.autoBonds;
+        checkbox.addEventListener('change', () => {
+            CONFIG.autoBonds = checkbox.checked;
+        });
+    }
+}
+// ── Render loop ───────────────────────────────────────────────
 const clock = new THREE.Clock();
 function loop() {
-  requestAnimationFrame(loop);
-  const dt = Math.min(clock.getDelta(), 1 / 30);
-  controls.update();
-  if (coreRef && visualsRef) {
-    coreRef.step(dt);
-    visualsRef.update({
-      debug: showDebug,
-      updateBVH: false,
-      updateProjectiles: true
-    });
-    rapierDebug?.update();
-    updateStatus(coreRef);
-  }
-  renderer.render(scene, camera);
+    requestAnimationFrame(loop);
+    stats.begin();
+    const dt = Math.min(clock.getDelta(), 1 / 30);
+    controls.update();
+    if (coreRef && visualsRef) {
+        const t0 = performance.now();
+        coreRef.step(dt);
+        _physicsMs += ((performance.now() - t0) - _physicsMs) * EMA;
+        visualsRef.update({
+            debug: showDebug,
+            updateBVH: false,
+            updateProjectiles: true,
+        });
+        rapierDebug?.update();
+        updateStatus(coreRef);
+    }
+    const t1 = performance.now();
+    renderer.render(scene, camera);
+    _renderMs += ((performance.now() - t1) - _renderMs) * EMA;
+    updatePerfStats();
+    stats.end();
 }
+// ── Resize ────────────────────────────────────────────────────
 function onResize() {
-  const w = canvas.clientWidth;
-  const h = canvas.clientHeight;
-  renderer.setSize(w, h, false);
-  camera.aspect = w / h;
-  camera.updateProjectionMatrix();
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h;
+    camera.updateProjectionMatrix();
 }
-window.addEventListener("resize", onResize);
+window.addEventListener('resize', onResize);
+// ── Boot ──────────────────────────────────────────────────────
 initScene().then(() => loop());

--- a/blast/js_stress_example/tower-collapse.html
+++ b/blast/js_stress_example/tower-collapse.html
@@ -116,7 +116,7 @@
 
         <!-- Status -->
         <section class="status-panel">
-          <h2>Status</h2>
+          <h2>Simulation</h2>
           <div class="status-grid">
             <div class="status-item">
               <span class="status-label">Bodies</span>
@@ -133,6 +133,29 @@
             <div class="status-item">
               <span class="status-label">Chunks</span>
               <span class="status-value" id="stat-chunks">0</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- Performance -->
+        <section class="status-panel">
+          <h2>Performance</h2>
+          <div class="status-grid">
+            <div class="status-item">
+              <span class="status-label">Physics</span>
+              <span class="status-value" id="stat-physics-ms">— ms</span>
+            </div>
+            <div class="status-item">
+              <span class="status-label">Render</span>
+              <span class="status-value" id="stat-render-ms">— ms</span>
+            </div>
+            <div class="status-item">
+              <span class="status-label">Draw Calls</span>
+              <span class="status-value" id="stat-draw-calls">0</span>
+            </div>
+            <div class="status-item">
+              <span class="status-label">Triangles</span>
+              <span class="status-value" id="stat-triangles">0</span>
             </div>
           </div>
         </section>

--- a/blast/js_stress_example/tower-collapse.ts
+++ b/blast/js_stress_example/tower-collapse.ts
@@ -9,6 +9,7 @@
 
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import Stats from 'three/addons/libs/stats.module.js';
 import { buildDestructibleCore } from 'blast-stress-solver/rapier';
 import {
   createDestructibleThreeBundle,
@@ -94,6 +95,28 @@ groundMesh.rotation.x = -Math.PI / 2;
 groundMesh.position.y = -0.4;
 groundMesh.receiveShadow = true;
 scene.add(groundMesh);
+
+// ── Stats panel (FPS / MS / MB) ───────────────────────────────
+
+const stats = new Stats();
+stats.dom.style.position = 'absolute';
+stats.dom.style.top = '0';
+stats.dom.style.left = '0';
+(document.querySelector('.viewport') as HTMLElement)?.appendChild(stats.dom);
+
+// ── Perf tracking ─────────────────────────────────────────────
+
+let _physicsMs = 0;
+let _renderMs = 0;
+const EMA = 0.12; // exponential moving-average smoothing factor
+
+function updatePerfStats() {
+  const el = (id: string) => document.getElementById(id);
+  el('stat-physics-ms')!.textContent = _physicsMs.toFixed(1) + ' ms';
+  el('stat-render-ms')!.textContent = _renderMs.toFixed(1) + ' ms';
+  el('stat-draw-calls')!.textContent = String(renderer.info.render.calls);
+  el('stat-triangles')!.textContent = renderer.info.render.triangles.toLocaleString();
+}
 
 // ── Status HUD ────────────────────────────────────────────────
 
@@ -284,12 +307,16 @@ const clock = new THREE.Clock();
 
 function loop() {
   requestAnimationFrame(loop);
+  stats.begin();
 
   const dt = Math.min(clock.getDelta(), 1 / 30);
   controls.update();
 
   if (coreRef && visualsRef) {
+    const t0 = performance.now();
     coreRef.step(dt);
+    _physicsMs += ((performance.now() - t0) - _physicsMs) * EMA;
+
     visualsRef.update({
       debug: showDebug,
       updateBVH: false,
@@ -299,7 +326,12 @@ function loop() {
     updateStatus(coreRef);
   }
 
+  const t1 = performance.now();
   renderer.render(scene, camera);
+  _renderMs += ((performance.now() - t1) - _renderMs) * EMA;
+
+  updatePerfStats();
+  stats.end();
 }
 
 // ── Resize ────────────────────────────────────────────────────

--- a/blast/js_stress_example/tsconfig.json
+++ b/blast/js_stress_example/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "module": "ES2020",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2020", "DOM"],
     "allowJs": true,
     "checkJs": false,

--- a/blast/js_stress_example/wall-demolition.html
+++ b/blast/js_stress_example/wall-demolition.html
@@ -116,7 +116,7 @@
 
         <!-- Status -->
         <section class="status-panel">
-          <h2>Status</h2>
+          <h2>Simulation</h2>
           <div class="status-grid">
             <div class="status-item">
               <span class="status-label">Bodies</span>
@@ -133,6 +133,29 @@
             <div class="status-item">
               <span class="status-label">Chunks</span>
               <span class="status-value" id="stat-chunks">0</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- Performance -->
+        <section class="status-panel">
+          <h2>Performance</h2>
+          <div class="status-grid">
+            <div class="status-item">
+              <span class="status-label">Physics</span>
+              <span class="status-value" id="stat-physics-ms">— ms</span>
+            </div>
+            <div class="status-item">
+              <span class="status-label">Render</span>
+              <span class="status-value" id="stat-render-ms">— ms</span>
+            </div>
+            <div class="status-item">
+              <span class="status-label">Draw Calls</span>
+              <span class="status-value" id="stat-draw-calls">0</span>
+            </div>
+            <div class="status-item">
+              <span class="status-label">Triangles</span>
+              <span class="status-value" id="stat-triangles">0</span>
             </div>
           </div>
         </section>

--- a/blast/js_stress_example/wall-demolition.ts
+++ b/blast/js_stress_example/wall-demolition.ts
@@ -9,6 +9,7 @@
 
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import Stats from 'three/addons/libs/stats.module.js';
 import { buildDestructibleCore } from 'blast-stress-solver/rapier';
 import {
   createDestructibleThreeBundle,
@@ -98,6 +99,28 @@ groundMesh.rotation.x = -Math.PI / 2;
 groundMesh.position.y = -0.35;
 groundMesh.receiveShadow = true;
 scene.add(groundMesh);
+
+// ── Stats panel (FPS / MS / MB) ───────────────────────────────
+
+const stats = new Stats();
+stats.dom.style.position = 'absolute';
+stats.dom.style.top = '0';
+stats.dom.style.left = '0';
+(document.querySelector('.viewport') as HTMLElement)?.appendChild(stats.dom);
+
+// ── Perf tracking ─────────────────────────────────────────────
+
+let _physicsMs = 0;
+let _renderMs = 0;
+const EMA = 0.12; // exponential moving-average smoothing factor
+
+function updatePerfStats() {
+  const el = (id: string) => document.getElementById(id);
+  el('stat-physics-ms')!.textContent = _physicsMs.toFixed(1) + ' ms';
+  el('stat-render-ms')!.textContent = _renderMs.toFixed(1) + ' ms';
+  el('stat-draw-calls')!.textContent = String(renderer.info.render.calls);
+  el('stat-triangles')!.textContent = renderer.info.render.triangles.toLocaleString();
+}
 
 // ── Status HUD ────────────────────────────────────────────────
 
@@ -285,12 +308,16 @@ const clock = new THREE.Clock();
 
 function loop() {
   requestAnimationFrame(loop);
+  stats.begin();
 
   const dt = Math.min(clock.getDelta(), 1 / 30);
   controls.update();
 
   if (coreRef && visualsRef) {
+    const t0 = performance.now();
     coreRef.step(dt);
+    _physicsMs += ((performance.now() - t0) - _physicsMs) * EMA;
+
     visualsRef.update({
       debug: showDebug,
       updateBVH: false,
@@ -300,7 +327,12 @@ function loop() {
     updateStatus(coreRef);
   }
 
+  const t1 = performance.now();
   renderer.render(scene, camera);
+  _renderMs += ((performance.now() - t1) - _renderMs) * EMA;
+
+  updatePerfStats();
+  stats.end();
 }
 
 // ── Resize ────────────────────────────────────────────────────


### PR DESCRIPTION
- Add Three.js Stats.js panel (FPS / MS / MB) as viewport overlay in tower-collapse and wall-demolition demos
- Measure and display Rapier physics step time and Three.js render time per frame using exponential moving average smoothing
- Show draw call count and triangle count from renderer.info in a new Performance sidebar section
- Fix tsconfig.json deprecation warning (ignoreDeprecations: 6.0 for moduleResolution node10)

https://claude.ai/code/session_01CSefH8jWVW64fiYL9ruzRo

<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->
