### PR TITLE
Add fractured tower and bridge scenarios with fragment type system

### DIFF
--- a/blast/blast-stress-solver/src/scenarios/fracturedBridgeScenario.ts
+++ b/blast/blast-stress-solver/src/scenarios/fracturedBridgeScenario.ts
@@ -1,0 +1,177 @@
+/**
+ * Pre-built fractured bridge scenario using Voronoi fracturing.
+ *
+ * Builds a beam bridge from a fractured deck slab, fractured support posts,
+ * and simple cuboid footing supports. Each component is independently
+ * fractured via three-pinata, then assembled into a single ScenarioDesc.
+ *
+ * Default geometry:
+ * - 18m span, 5m wide deck, 0.6m thick
+ * - 4 support posts per side at each end
+ * - Posts sit on thin footing plates (mass=0 supports)
+ *
+ * Requires @dgreenheck/three-pinata as an optional peer dependency.
+ */
+import * as THREE from 'three';
+import type { ScenarioDesc } from '../rapier/types';
+import type { FragmentInfo } from '../three/fracture';
+import type { AreaNormalizationMode } from '../three/scenarioFromFragments';
+import {
+  buildFloorFragments,
+  buildColumnFragments,
+} from '../three/fractureBuilders';
+import {
+  buildScenarioFromFragments,
+  buildScenarioFromFragmentsAsync,
+} from '../three/scenarioFromFragments';
+
+export type FracturedBridgeOptions = {
+  /** X length of deck in meters (default: 18) */
+  span?: number;
+  /** Z width of deck in meters (default: 5) */
+  deckWidth?: number;
+  /** Y thickness of deck in meters (default: 0.6) */
+  deckThickness?: number;
+  /** Distance from ground to deck bottom in meters (default: 2.8) */
+  pierHeight?: number;
+  /** Number of vertical posts at each end across Z (default: 4) */
+  supportsPerSide?: number;
+  /** Cross-section size of each support post in meters (default: 0.4) */
+  postSize?: number;
+  /** Thin foundation plate thickness in meters (default: 0.12) */
+  footingThickness?: number;
+  /** Number of Voronoi fragments for the deck (default: 40) */
+  fragmentCountPerDeck?: number;
+  /** Number of Voronoi fragments per post (default: 5) */
+  fragmentCountPerPost?: number;
+  /** Total mass distributed among deck blocks in kg (default: 60000) */
+  deckMass?: number;
+  /** Bond detection mode: 'proximity' (default) or 'auto' (WASM triangle-based) */
+  bondMode?: 'proximity' | 'auto';
+  /** Bond area normalization mode (default: 'perAxis') */
+  areaNormalization?: AreaNormalizationMode;
+  /** Rapier module for convex hull colliders. If omitted, colliderDescForNode entries are null. */
+  rapier?: { ColliderDesc: { cuboid(hx: number, hy: number, hz: number): unknown; convexHull(points: Float32Array): unknown | null } };
+};
+
+/**
+ * Build a fractured beam bridge scenario.
+ *
+ * The deck is a single fractured slab spanning the full bridge length.
+ * Support posts at each end are independently fractured vertical columns.
+ * Footings under each post are simple cuboid supports (mass=0).
+ */
+export async function buildFracturedBridgeScenario(
+  options?: FracturedBridgeOptions,
+): Promise<ScenarioDesc> {
+  const {
+    span = 18.0,
+    deckWidth = 5.0,
+    deckThickness = 0.6,
+    pierHeight = 2.8,
+    supportsPerSide = 4,
+    postSize = 0.4,
+    footingThickness = 0.12,
+    fragmentCountPerDeck = 40,
+    fragmentCountPerPost = 5,
+    deckMass = 60_000,
+    bondMode = 'proximity',
+    areaNormalization = 'perAxis',
+    rapier,
+  } = options ?? {};
+
+  const groundClearance = 0.001;
+  const deckBottomY = groundClearance + footingThickness + pierHeight;
+  const deckCenterY = deckBottomY + deckThickness * 0.5;
+
+  const allFragments: FragmentInfo[] = [];
+
+  // ── Deck slab ──────────────────────────────────────────────
+  allFragments.push(...buildFloorFragments({
+    spanX: span,
+    spanZ: deckWidth,
+    thickness: deckThickness,
+    fragmentCount: fragmentCountPerDeck,
+    centerX: 0,
+    centerY: deckCenterY,
+    centerZ: 0,
+  }));
+
+  // ── Support posts at each end ──────────────────────────────
+  const halfSpan = span * 0.5;
+  const halfWidth = deckWidth * 0.5;
+
+  // Evenly distribute posts across deck width
+  const postZPositions: number[] = [];
+  for (let i = 0; i < supportsPerSide; i++) {
+    const t = supportsPerSide === 1 ? 0.5 : i / (supportsPerSide - 1);
+    postZPositions.push(-halfWidth + postSize * 0.5 + t * (deckWidth - postSize));
+  }
+
+  // Posts at X = -halfSpan and X = +halfSpan
+  const postXPositions = [
+    -halfSpan + postSize * 0.5,
+    halfSpan - postSize * 0.5,
+  ];
+
+  for (const postX of postXPositions) {
+    for (const postZ of postZPositions) {
+      // Fractured support post
+      allFragments.push(...buildColumnFragments({
+        sizeX: postSize,
+        sizeZ: postSize,
+        height: pierHeight,
+        fragmentCount: fragmentCountPerPost,
+        centerX: postX,
+        baseY: groundClearance + footingThickness,
+        centerZ: postZ,
+      }));
+
+      // Footing support under each post (simple cuboid, mass=0)
+      allFragments.push({
+        worldPosition: {
+          x: postX,
+          y: groundClearance + footingThickness * 0.5,
+          z: postZ,
+        },
+        halfExtents: {
+          x: postSize * 0.5,
+          y: footingThickness * 0.5,
+          z: postSize * 0.5,
+        },
+        geometry: new THREE.BoxGeometry(postSize, footingThickness, postSize),
+        isSupport: true,
+        fragmentType: 'foundation',
+      });
+    }
+  }
+
+  // ── Build scenario ─────────────────────────────────────────
+  const dims = {
+    x: span,
+    y: deckThickness + pierHeight + footingThickness,
+    z: deckWidth,
+  };
+
+  const scenarioOptions = {
+    totalMass: deckMass,
+    bondMode: bondMode as 'proximity' | 'auto',
+    areaNormalization,
+    dimensions: dims,
+    rapier,
+  };
+
+  const scenario = bondMode === 'auto'
+    ? await buildScenarioFromFragmentsAsync(allFragments, scenarioOptions)
+    : buildScenarioFromFragments(allFragments, scenarioOptions);
+
+  // Store metadata
+  scenario.parameters = {
+    ...scenario.parameters,
+    span, deckWidth, deckThickness, pierHeight,
+    supportsPerSide, postSize, footingThickness,
+    fragmentCountPerDeck, fragmentCountPerPost,
+  };
+
+  return scenario;
+}

--- a/blast/blast-stress-solver/src/scenarios/fracturedBridgeScenario.ts
+++ b/blast/blast-stress-solver/src/scenarios/fracturedBridgeScenario.ts
@@ -15,6 +15,7 @@
 import * as THREE from 'three';
 import type { ScenarioDesc } from '../rapier/types';
 import type { FragmentInfo } from '../three/fracture';
+import type { PinataModule } from '../three/pinataFracture';
 import type { AreaNormalizationMode } from '../three/scenarioFromFragments';
 import {
   buildFloorFragments,
@@ -50,6 +51,11 @@ export type FracturedBridgeOptions = {
   bondMode?: 'proximity' | 'auto';
   /** Bond area normalization mode (default: 'perAxis') */
   areaNormalization?: AreaNormalizationMode;
+  /**
+   * Pre-imported three-pinata module. Required in browser ESM environments where
+   * the scenarios bundle cannot dynamically import bare specifiers.
+   */
+  pinata?: PinataModule;
   /** Rapier module for convex hull colliders. If omitted, colliderDescForNode entries are null. */
   rapier?: { ColliderDesc: { cuboid(hx: number, hy: number, hz: number): unknown; convexHull(points: Float32Array): unknown | null } };
 };
@@ -77,6 +83,7 @@ export async function buildFracturedBridgeScenario(
     deckMass = 60_000,
     bondMode = 'proximity',
     areaNormalization = 'perAxis',
+    pinata,
     rapier,
   } = options ?? {};
 
@@ -95,6 +102,7 @@ export async function buildFracturedBridgeScenario(
     centerX: 0,
     centerY: deckCenterY,
     centerZ: 0,
+    pinata,
   }));
 
   // ── Support posts at each end ──────────────────────────────
@@ -125,6 +133,7 @@ export async function buildFracturedBridgeScenario(
         centerX: postX,
         baseY: groundClearance + footingThickness,
         centerZ: postZ,
+        pinata,
       }));
 
       // Footing support under each post (simple cuboid, mass=0)

--- a/blast/blast-stress-solver/src/scenarios/fracturedTowerScenario.ts
+++ b/blast/blast-stress-solver/src/scenarios/fracturedTowerScenario.ts
@@ -17,6 +17,7 @@
  */
 import type { ScenarioDesc } from '../rapier/types';
 import type { FragmentInfo, FragmentType } from '../three/fracture';
+import type { PinataModule } from '../three/pinataFracture';
 import type { AreaNormalizationMode } from '../three/scenarioFromFragments';
 import {
   buildWallFragments,
@@ -67,6 +68,16 @@ export type FracturedTowerOptions = {
   bondMode?: 'proximity' | 'auto';
   /** Bond area normalization mode (default: 'perAxis') */
   areaNormalization?: AreaNormalizationMode;
+  /**
+   * Pre-imported three-pinata module. Required in browser ESM environments where
+   * the scenarios bundle cannot dynamically import bare specifiers.
+   * @example
+   * ```ts
+   * import * as pinata from '@dgreenheck/three-pinata';
+   * buildFracturedTowerScenario({ pinata });
+   * ```
+   */
+  pinata?: PinataModule;
   /** Rapier module for convex hull colliders. If omitted, colliderDescForNode entries are null. */
   rapier?: { ColliderDesc: { cuboid(hx: number, hy: number, hz: number): unknown; convexHull(points: Float32Array): unknown | null } };
 };
@@ -100,6 +111,7 @@ export async function buildFracturedTowerScenario(
     deckMass,
     bondMode = 'proximity',
     areaNormalization = 'perAxis',
+    pinata,
     rapier,
   } = options ?? {};
 
@@ -165,7 +177,7 @@ export async function buildFracturedTowerScenario(
       span: width, height: wallHeight, thickness,
       fragmentCount: fragmentCountPerWall,
       centerX: 0, centerZ: -halfDepth + thickness * 0.5,
-      rotationY: 0, baseY: wallBottomY,
+      rotationY: 0, baseY: wallBottomY, pinata,
     }));
 
     // Back wall
@@ -173,7 +185,7 @@ export async function buildFracturedTowerScenario(
       span: width, height: wallHeight, thickness,
       fragmentCount: fragmentCountPerWall,
       centerX: 0, centerZ: halfDepth - thickness * 0.5,
-      rotationY: 0, baseY: wallBottomY,
+      rotationY: 0, baseY: wallBottomY, pinata,
     }));
 
     // Left wall (rotated 90 degrees)
@@ -181,7 +193,7 @@ export async function buildFracturedTowerScenario(
       span: sideWallSpan, height: wallHeight, thickness,
       fragmentCount: fragmentCountPerWall,
       centerX: -halfWidth + thickness * 0.5, centerZ: 0,
-      rotationY: Math.PI * 0.5, baseY: wallBottomY,
+      rotationY: Math.PI * 0.5, baseY: wallBottomY, pinata,
     }));
 
     // Right wall (rotated 90 degrees)
@@ -189,7 +201,7 @@ export async function buildFracturedTowerScenario(
       span: sideWallSpan, height: wallHeight, thickness,
       fragmentCount: fragmentCountPerWall,
       centerX: halfWidth - thickness * 0.5, centerZ: 0,
-      rotationY: Math.PI * 0.5, baseY: wallBottomY,
+      rotationY: Math.PI * 0.5, baseY: wallBottomY, pinata,
     }));
 
     // Interior columns for this floor section
@@ -197,7 +209,7 @@ export async function buildFracturedTowerScenario(
       allFragments.push(...buildColumnFragments({
         sizeX: columnSize, sizeZ: columnSize, height: wallHeight,
         fragmentCount: fragmentCountPerColumn,
-        centerX: colPos.x, baseY: wallBottomY, centerZ: colPos.z,
+        centerX: colPos.x, baseY: wallBottomY, centerZ: colPos.z, pinata,
       }));
     }
   }
@@ -207,7 +219,7 @@ export async function buildFracturedTowerScenario(
     allFragments.push(...buildFloorFragments({
       spanX: width, spanZ: depth, thickness: floorThickness,
       fragmentCount: fragmentCountPerFloor,
-      centerX: 0, centerY: floorHeights[floorIdx], centerZ: 0,
+      centerX: 0, centerY: floorHeights[floorIdx], centerZ: 0, pinata,
     }));
   }
 
@@ -217,7 +229,7 @@ export async function buildFracturedTowerScenario(
   allFragments.push(...buildFloorFragments({
     spanX: width, spanZ: depth, thickness: floorThickness,
     fragmentCount: fragmentCountPerFloor,
-    centerX: 0, centerY: roofY, centerZ: 0,
+    centerX: 0, centerY: roofY, centerZ: 0, pinata,
   }));
 
   // Grid foundation

--- a/blast/blast-stress-solver/src/scenarios/fracturedTowerScenario.ts
+++ b/blast/blast-stress-solver/src/scenarios/fracturedTowerScenario.ts
@@ -1,0 +1,263 @@
+/**
+ * Pre-built fractured tower scenario using Voronoi fracturing.
+ *
+ * Builds a multi-floor tower from fractured walls, floor plates, interior
+ * columns, and a grid foundation. Each component is independently fractured
+ * via three-pinata, then assembled into a single ScenarioDesc with bond
+ * detection and type-based bond strength multipliers.
+ *
+ * Realistic skyscraper defaults:
+ * - 40m x 40m footprint (typical mid-rise office building)
+ * - 4m floor-to-floor height (commercial standard)
+ * - 20 floors (~80m total height)
+ * - Interior column grid (~8m spacing, auto-calculated)
+ * - ~600 kg/m^2 per floor (reinforced concrete)
+ *
+ * Requires @dgreenheck/three-pinata as an optional peer dependency.
+ */
+import type { ScenarioDesc } from '../rapier/types';
+import type { FragmentInfo, FragmentType } from '../three/fracture';
+import type { AreaNormalizationMode } from '../three/scenarioFromFragments';
+import {
+  buildWallFragments,
+  buildFloorFragments,
+  buildColumnFragments,
+  buildGridFoundationFragments,
+  applyBondStrengthMultipliers,
+} from '../three/fractureBuilders';
+import {
+  buildScenarioFromFragments,
+  buildScenarioFromFragmentsAsync,
+} from '../three/scenarioFromFragments';
+
+export type FracturedTowerOptions = {
+  /** Width of the tower footprint (X dimension) in meters (default: 40) */
+  width?: number;
+  /** Depth of the tower footprint (Z dimension) in meters (default: 40) */
+  depth?: number;
+  /** Number of floors / stories (default: 20) */
+  floorCount?: number;
+  /** Floor-to-floor height in meters (default: 4) */
+  floorHeight?: number;
+  /** Total height override — if provided, ignores floorCount x floorHeight */
+  height?: number;
+  /** Exterior wall thickness in meters (default: 0.4) */
+  thickness?: number;
+  /** Floor slab thickness in meters (default: 0.35) */
+  floorThickness?: number;
+  /** Interior column cross-section size in meters (default: 1.2) */
+  columnSize?: number;
+  /** Number of columns in X direction. Auto-calculated from columnSpacing if omitted. */
+  columnsX?: number;
+  /** Number of columns in Z direction. Auto-calculated from columnSpacing if omitted. */
+  columnsZ?: number;
+  /** Target spacing between columns in meters (default: 8) */
+  columnSpacing?: number;
+  /** Inset from walls to first column row (fraction 0–0.5, default: 0.15) */
+  columnInset?: number;
+  /** Voronoi fragment count per wall section per floor (default: 12) */
+  fragmentCountPerWall?: number;
+  /** Voronoi fragment count per floor plate (default: 8) */
+  fragmentCountPerFloor?: number;
+  /** Voronoi fragment count per column section (default: 4) */
+  fragmentCountPerColumn?: number;
+  /** Total structure mass in kg. Auto-calculated (~600 kg/m^2 per floor) if omitted. */
+  deckMass?: number;
+  /** Bond detection mode: 'proximity' (default) or 'auto' (WASM triangle-based) */
+  bondMode?: 'proximity' | 'auto';
+  /** Bond area normalization mode (default: 'perAxis') */
+  areaNormalization?: AreaNormalizationMode;
+  /** Rapier module for convex hull colliders. If omitted, colliderDescForNode entries are null. */
+  rapier?: { ColliderDesc: { cuboid(hx: number, hy: number, hz: number): unknown; convexHull(points: Float32Array): unknown | null } };
+};
+
+/**
+ * Build a multi-floor fractured tower scenario.
+ *
+ * Each floor section consists of 4 exterior walls, interior columns,
+ * and a floor plate. The ground floor sits on a grid foundation;
+ * upper walls sit on floor plates to ensure proper bonding surfaces.
+ */
+export async function buildFracturedTowerScenario(
+  options?: FracturedTowerOptions,
+): Promise<ScenarioDesc> {
+  const {
+    width = 40,
+    depth = 40,
+    floorCount = 20,
+    floorHeight = 4,
+    height,
+    thickness = 0.4,
+    floorThickness = 0.35,
+    columnSize = 1.2,
+    columnsX,
+    columnsZ,
+    columnSpacing = 8,
+    columnInset = 0.15,
+    fragmentCountPerWall = 12,
+    fragmentCountPerFloor = 8,
+    fragmentCountPerColumn = 4,
+    deckMass,
+    bondMode = 'proximity',
+    areaNormalization = 'perAxis',
+    rapier,
+  } = options ?? {};
+
+  const totalHeight = height ?? floorCount * floorHeight;
+
+  // ~600 kg/m^2 per floor (typical reinforced concrete office building)
+  const floorArea = width * depth;
+  const calculatedMass = deckMass ?? floorArea * floorCount * 600;
+
+  // Foundation
+  const foundationHeight = Math.max(0.5, totalHeight * 0.01);
+  const groundClearance = Math.max(0.01, foundationHeight * 0.05);
+  const baseY = groundClearance + foundationHeight;
+
+  // Floor level Y coordinates
+  const floorHeights: number[] = [];
+  for (let i = 0; i <= floorCount; i++) {
+    floorHeights.push(baseY + i * floorHeight);
+  }
+
+  const halfWidth = width * 0.5;
+  const halfDepth = depth * 0.5;
+
+  // Interior column grid
+  const interiorWidth = width - thickness * 2;
+  const interiorDepth = depth - thickness * 2;
+  const numColumnsX = columnsX ?? Math.max(2, Math.round(interiorWidth / columnSpacing));
+  const numColumnsZ = columnsZ ?? Math.max(2, Math.round(interiorDepth / columnSpacing));
+
+  const columnRangeX = interiorWidth * (1 - 2 * columnInset);
+  const columnRangeZ = interiorDepth * (1 - 2 * columnInset);
+  const columnStartX = -columnRangeX * 0.5;
+  const columnStartZ = -columnRangeZ * 0.5;
+
+  const columnPositions: Array<{ x: number; z: number }> = [];
+  for (let ix = 0; ix < numColumnsX; ix++) {
+    for (let iz = 0; iz < numColumnsZ; iz++) {
+      const tx = numColumnsX > 1 ? ix / (numColumnsX - 1) : 0.5;
+      const tz = numColumnsZ > 1 ? iz / (numColumnsZ - 1) : 0.5;
+      columnPositions.push({
+        x: columnStartX + tx * columnRangeX,
+        z: columnStartZ + tz * columnRangeZ,
+      });
+    }
+  }
+
+  // ── Collect all fragments ──────────────────────────────────
+  const allFragments: FragmentInfo[] = [];
+
+  // Walls + columns for each floor section
+  for (let floorIdx = 0; floorIdx < floorHeights.length - 1; floorIdx++) {
+    const wallBottomY = floorIdx === 0
+      ? floorHeights[0]
+      : floorHeights[floorIdx] + floorThickness * 0.5;
+    const wallTopY = floorHeights[floorIdx + 1] - floorThickness * 0.5;
+    const wallHeight = wallTopY - wallBottomY;
+    if (wallHeight <= 0.1) continue;
+
+    const sideWallSpan = depth - thickness * 2;
+
+    // Front wall
+    allFragments.push(...buildWallFragments({
+      span: width, height: wallHeight, thickness,
+      fragmentCount: fragmentCountPerWall,
+      centerX: 0, centerZ: -halfDepth + thickness * 0.5,
+      rotationY: 0, baseY: wallBottomY,
+    }));
+
+    // Back wall
+    allFragments.push(...buildWallFragments({
+      span: width, height: wallHeight, thickness,
+      fragmentCount: fragmentCountPerWall,
+      centerX: 0, centerZ: halfDepth - thickness * 0.5,
+      rotationY: 0, baseY: wallBottomY,
+    }));
+
+    // Left wall (rotated 90 degrees)
+    allFragments.push(...buildWallFragments({
+      span: sideWallSpan, height: wallHeight, thickness,
+      fragmentCount: fragmentCountPerWall,
+      centerX: -halfWidth + thickness * 0.5, centerZ: 0,
+      rotationY: Math.PI * 0.5, baseY: wallBottomY,
+    }));
+
+    // Right wall (rotated 90 degrees)
+    allFragments.push(...buildWallFragments({
+      span: sideWallSpan, height: wallHeight, thickness,
+      fragmentCount: fragmentCountPerWall,
+      centerX: halfWidth - thickness * 0.5, centerZ: 0,
+      rotationY: Math.PI * 0.5, baseY: wallBottomY,
+    }));
+
+    // Interior columns for this floor section
+    for (const colPos of columnPositions) {
+      allFragments.push(...buildColumnFragments({
+        sizeX: columnSize, sizeZ: columnSize, height: wallHeight,
+        fragmentCount: fragmentCountPerColumn,
+        centerX: colPos.x, baseY: wallBottomY, centerZ: colPos.z,
+      }));
+    }
+  }
+
+  // Floor plates (skip ground floor — covered by foundation)
+  for (let floorIdx = 1; floorIdx < floorHeights.length - 1; floorIdx++) {
+    allFragments.push(...buildFloorFragments({
+      spanX: width, spanZ: depth, thickness: floorThickness,
+      fragmentCount: fragmentCountPerFloor,
+      centerX: 0, centerY: floorHeights[floorIdx], centerZ: 0,
+    }));
+  }
+
+  // Roof plate at the top
+  const lastWallTopY = floorHeights[floorCount] - floorThickness * 0.5;
+  const roofY = lastWallTopY + floorThickness * 0.5;
+  allFragments.push(...buildFloorFragments({
+    spanX: width, spanZ: depth, thickness: floorThickness,
+    fragmentCount: fragmentCountPerFloor,
+    centerX: 0, centerY: roofY, centerZ: 0,
+  }));
+
+  // Grid foundation
+  const { fragments: foundationFragments } = buildGridFoundationFragments({
+    width, depth,
+    height: foundationHeight,
+    groundClearance,
+  });
+  allFragments.push(...foundationFragments);
+
+  // ── Build scenario ─────────────────────────────────────────
+  const dims = { x: width, y: totalHeight, z: depth };
+
+  const scenarioOptions = {
+    totalMass: calculatedMass,
+    bondMode: bondMode as 'proximity' | 'auto',
+    areaNormalization,
+    dimensions: dims,
+    rapier,
+  };
+
+  const scenario = bondMode === 'auto'
+    ? await buildScenarioFromFragmentsAsync(allFragments, scenarioOptions)
+    : buildScenarioFromFragments(allFragments, scenarioOptions);
+
+  // Apply type-based bond strength multipliers
+  const fragmentTypes: (FragmentType | undefined)[] = allFragments.map((f) => f.fragmentType);
+  scenario.bonds = applyBondStrengthMultipliers(scenario.bonds, fragmentTypes);
+
+  // Store metadata
+  scenario.parameters = {
+    ...scenario.parameters,
+    width, depth, height: totalHeight,
+    thickness, floorThickness, columnSize,
+    columnsX: numColumnsX, columnsZ: numColumnsZ,
+    columnSpacing, columnInset,
+    totalColumns: columnPositions.length,
+    floorCount, floorHeight,
+    fragmentCountPerWall, fragmentCountPerFloor, fragmentCountPerColumn,
+  };
+
+  return scenario;
+}

--- a/blast/blast-stress-solver/src/scenarios/index.ts
+++ b/blast/blast-stress-solver/src/scenarios/index.ts
@@ -9,3 +9,9 @@ export type { BeamBridgeOptions } from './bridgeScenario';
 
 export { buildFracturedWallScenario, DEFAULT_FRACTURED_WALL_OPTIONS } from './fracturedWallScenario';
 export type { FracturedWallOptions } from './fracturedWallScenario';
+
+export { buildFracturedTowerScenario } from './fracturedTowerScenario';
+export type { FracturedTowerOptions } from './fracturedTowerScenario';
+
+export { buildFracturedBridgeScenario } from './fracturedBridgeScenario';
+export type { FracturedBridgeOptions } from './fracturedBridgeScenario';

--- a/blast/blast-stress-solver/src/tests/scenarios.fractured.test.ts
+++ b/blast/blast-stress-solver/src/tests/scenarios.fractured.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for fractured tower and fractured bridge scenarios.
+ *
+ * Tests verify:
+ * - Scenario produces valid ScenarioDesc (nodes, bonds, parameters)
+ * - Support/dynamic node distribution is correct
+ * - Bond strength multipliers are applied
+ * - Small configurations for fast test execution
+ *
+ * Requires @dgreenheck/three-pinata (skips gracefully if unavailable).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+let pinataAvailable = false;
+try {
+  require.resolve('@dgreenheck/three-pinata');
+  pinataAvailable = true;
+} catch {
+  pinataAvailable = false;
+}
+
+describe('Fractured scenarios (requires three-pinata)', () => {
+  beforeAll(async () => {
+    if (pinataAvailable) {
+      const { ensurePinataLoaded } = await import('../three/pinataFracture');
+      await ensurePinataLoaded();
+    }
+  });
+
+  // ── Fractured Tower ─────────────────────────────────────────
+
+  describe('buildFracturedTowerScenario', () => {
+    it.skipIf(!pinataAvailable)('produces valid scenario with small config', async () => {
+      const { buildFracturedTowerScenario } = await import('../scenarios/fracturedTowerScenario');
+
+      const scenario = await buildFracturedTowerScenario({
+        width: 6,
+        depth: 6,
+        floorCount: 2,
+        floorHeight: 3,
+        thickness: 0.3,
+        floorThickness: 0.2,
+        columnSize: 0.6,
+        columnsX: 2,
+        columnsZ: 2,
+        fragmentCountPerWall: 4,
+        fragmentCountPerFloor: 4,
+        fragmentCountPerColumn: 2,
+        deckMass: 5000,
+      });
+
+      expect(scenario.nodes.length).toBeGreaterThan(0);
+      expect(scenario.bonds.length).toBeGreaterThan(0);
+
+      // Should have both support and dynamic nodes
+      const supports = scenario.nodes.filter((n) => n.mass === 0);
+      const dynamic = scenario.nodes.filter((n) => n.mass > 0);
+      expect(supports.length).toBeGreaterThan(0);
+      expect(dynamic.length).toBeGreaterThan(0);
+
+      // Total dynamic mass should match deckMass
+      const totalMass = dynamic.reduce((s, n) => s + n.mass, 0);
+      expect(totalMass).toBeCloseTo(5000, -1); // within 10%
+
+      // Parameters should include metadata
+      expect(scenario.parameters).toBeDefined();
+      expect(scenario.parameters!.floorCount).toBe(2);
+      expect(scenario.parameters!.width).toBe(6);
+    });
+
+    it.skipIf(!pinataAvailable)('fragment geometries are stored in parameters', async () => {
+      const { buildFracturedTowerScenario } = await import('../scenarios/fracturedTowerScenario');
+
+      const scenario = await buildFracturedTowerScenario({
+        width: 4, depth: 4, floorCount: 1,
+        fragmentCountPerWall: 3,
+        fragmentCountPerFloor: 3,
+        fragmentCountPerColumn: 2,
+        columnsX: 1, columnsZ: 1,
+      });
+
+      const geoms = scenario.parameters?.fragmentGeometries as unknown[];
+      expect(geoms).toBeDefined();
+      expect(geoms.length).toBe(scenario.nodes.length);
+    });
+
+    it.skipIf(!pinataAvailable)('bonds have type-based strength multipliers applied', async () => {
+      const { buildFracturedTowerScenario } = await import('../scenarios/fracturedTowerScenario');
+
+      const scenario = await buildFracturedTowerScenario({
+        width: 6, depth: 6, floorCount: 1,
+        floorHeight: 3, thickness: 0.3, floorThickness: 0.2,
+        columnSize: 0.6, columnsX: 2, columnsZ: 2,
+        fragmentCountPerWall: 3,
+        fragmentCountPerFloor: 3,
+        fragmentCountPerColumn: 2,
+        deckMass: 2000,
+      });
+
+      // With columns, floors, and walls, we should see bonds with different areas.
+      // Column-column bonds (if any) should have 4x the area of wall-wall bonds.
+      // Just verify bonds exist and have positive areas.
+      expect(scenario.bonds.length).toBeGreaterThan(0);
+      for (const bond of scenario.bonds) {
+        expect(bond.area).toBeGreaterThan(0);
+        expect(Number.isFinite(bond.area)).toBe(true);
+      }
+    });
+  });
+
+  // ── Fractured Bridge ────────────────────────────────────────
+
+  describe('buildFracturedBridgeScenario', () => {
+    it.skipIf(!pinataAvailable)('produces valid scenario with default config', async () => {
+      const { buildFracturedBridgeScenario } = await import('../scenarios/fracturedBridgeScenario');
+
+      const scenario = await buildFracturedBridgeScenario({
+        span: 6,
+        deckWidth: 2,
+        deckThickness: 0.3,
+        pierHeight: 1.5,
+        supportsPerSide: 2,
+        postSize: 0.3,
+        fragmentCountPerDeck: 8,
+        fragmentCountPerPost: 3,
+        deckMass: 5000,
+      });
+
+      expect(scenario.nodes.length).toBeGreaterThan(0);
+      expect(scenario.bonds.length).toBeGreaterThan(0);
+
+      // Should have support nodes (footings)
+      const supports = scenario.nodes.filter((n) => n.mass === 0);
+      expect(supports.length).toBe(4); // 2 sides x 2 posts = 4 footings
+
+      // Total dynamic mass should match deckMass
+      const dynamic = scenario.nodes.filter((n) => n.mass > 0);
+      const totalMass = dynamic.reduce((s, n) => s + n.mass, 0);
+      expect(totalMass).toBeCloseTo(5000, -1);
+
+      // Parameters should include metadata
+      expect(scenario.parameters!.span).toBe(6);
+      expect(scenario.parameters!.supportsPerSide).toBe(2);
+    });
+
+    it.skipIf(!pinataAvailable)('deck fragments are positioned above posts', async () => {
+      const { buildFracturedBridgeScenario } = await import('../scenarios/fracturedBridgeScenario');
+
+      const pierHeight = 2.0;
+      const deckThickness = 0.4;
+      const footingThickness = 0.12;
+      const scenario = await buildFracturedBridgeScenario({
+        span: 4, deckWidth: 2,
+        deckThickness, pierHeight,
+        supportsPerSide: 2,
+        fragmentCountPerDeck: 4,
+        fragmentCountPerPost: 2,
+        footingThickness,
+      });
+
+      const deckBottomY = 0.001 + footingThickness + pierHeight;
+      const dynamic = scenario.nodes.filter((n) => n.mass > 0);
+
+      // At least some fragments should be at deck height
+      const deckFragments = dynamic.filter(
+        (n) => n.centroid.y > deckBottomY - 0.1,
+      );
+      expect(deckFragments.length).toBeGreaterThan(0);
+    });
+
+    it.skipIf(!pinataAvailable)('fragment geometries are stored in parameters', async () => {
+      const { buildFracturedBridgeScenario } = await import('../scenarios/fracturedBridgeScenario');
+
+      const scenario = await buildFracturedBridgeScenario({
+        span: 4, deckWidth: 2,
+        supportsPerSide: 2,
+        fragmentCountPerDeck: 4,
+        fragmentCountPerPost: 2,
+      });
+
+      const geoms = scenario.parameters?.fragmentGeometries as unknown[];
+      expect(geoms).toBeDefined();
+      expect(geoms.length).toBe(scenario.nodes.length);
+    });
+  });
+});

--- a/blast/blast-stress-solver/src/tests/three.fractureBuilders.test.ts
+++ b/blast/blast-stress-solver/src/tests/three.fractureBuilders.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for fracture builder functions (wall, floor, column, foundation)
+ * and bond strength multipliers.
+ *
+ * Fragment builder tests require @dgreenheck/three-pinata.
+ * Bond strength multiplier tests are always available (no deps).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as THREE from 'three';
+
+// Check synchronously at module load time so skipIf works
+let pinataAvailable = false;
+try {
+  require.resolve('@dgreenheck/three-pinata');
+  pinataAvailable = true;
+} catch {
+  pinataAvailable = false;
+}
+
+describe('fractureBuilders', () => {
+  beforeAll(async () => {
+    if (pinataAvailable) {
+      const { ensurePinataLoaded } = await import('../three/pinataFracture');
+      await ensurePinataLoaded();
+    }
+  });
+
+  // ── Wall fragments ──────────────────────────────────────────
+
+  describe('buildWallFragments (requires three-pinata)', () => {
+    it.skipIf(!pinataAvailable)('produces fragments with wall type', async () => {
+      const { buildWallFragments } = await import('../three/fractureBuilders');
+
+      const fragments = buildWallFragments({
+        span: 4, height: 2, thickness: 0.3,
+        fragmentCount: 6,
+      });
+
+      expect(fragments.length).toBeGreaterThan(0);
+      for (const f of fragments) {
+        expect(f.fragmentType).toBe('wall');
+        expect(f.isSupport).toBe(false);
+        expect(f.geometry).toBeInstanceOf(THREE.BufferGeometry);
+        expect(f.halfExtents.x).toBeGreaterThan(0);
+        expect(f.halfExtents.y).toBeGreaterThan(0);
+        expect(f.halfExtents.z).toBeGreaterThan(0);
+      }
+    });
+
+    it.skipIf(!pinataAvailable)('positions fragments at specified baseY', async () => {
+      const { buildWallFragments } = await import('../three/fractureBuilders');
+
+      const baseY = 5.0;
+      const height = 3.0;
+      const fragments = buildWallFragments({
+        span: 4, height, thickness: 0.3,
+        fragmentCount: 4,
+        baseY,
+      });
+
+      // All fragments should be above baseY and below baseY + height
+      for (const f of fragments) {
+        expect(f.worldPosition.y).toBeGreaterThanOrEqual(baseY - 0.01);
+        expect(f.worldPosition.y).toBeLessThanOrEqual(baseY + height + 0.01);
+      }
+    });
+
+    it.skipIf(!pinataAvailable)('applies rotation for side walls', async () => {
+      const { buildWallFragments } = await import('../three/fractureBuilders');
+
+      const unrotated = buildWallFragments({
+        span: 6, height: 2, thickness: 0.3,
+        fragmentCount: 4,
+        rotationY: 0,
+      });
+
+      const rotated = buildWallFragments({
+        span: 6, height: 2, thickness: 0.3,
+        fragmentCount: 4,
+        rotationY: Math.PI * 0.5,
+      });
+
+      // Unrotated wall spans X; rotated wall spans Z
+      // Check that rotated fragments have different X/Z distribution
+      const unrotMaxX = Math.max(...unrotated.map((f) => Math.abs(f.worldPosition.x)));
+      const rotMaxZ = Math.max(...rotated.map((f) => Math.abs(f.worldPosition.z)));
+
+      // Both should have significant extent in their primary direction
+      expect(unrotMaxX).toBeGreaterThan(0.5);
+      expect(rotMaxZ).toBeGreaterThan(0.5);
+    });
+  });
+
+  // ── Floor fragments ─────────────────────────────────────────
+
+  describe('buildFloorFragments (requires three-pinata)', () => {
+    it.skipIf(!pinataAvailable)('produces fragments with floor type', async () => {
+      const { buildFloorFragments } = await import('../three/fractureBuilders');
+
+      const centerY = 10.0;
+      const fragments = buildFloorFragments({
+        spanX: 6, spanZ: 6, thickness: 0.35,
+        fragmentCount: 6,
+        centerY,
+      });
+
+      expect(fragments.length).toBeGreaterThan(0);
+      for (const f of fragments) {
+        expect(f.fragmentType).toBe('floor');
+        expect(f.isSupport).toBe(false);
+        // Floor fragments should be near centerY
+        expect(Math.abs(f.worldPosition.y - centerY)).toBeLessThan(1.0);
+      }
+    });
+  });
+
+  // ── Column fragments ────────────────────────────────────────
+
+  describe('buildColumnFragments (requires three-pinata)', () => {
+    it.skipIf(!pinataAvailable)('produces fragments with column type', async () => {
+      const { buildColumnFragments } = await import('../three/fractureBuilders');
+
+      const fragments = buildColumnFragments({
+        sizeX: 0.8, sizeZ: 0.8, height: 3.0,
+        fragmentCount: 4,
+        baseY: 1.0,
+      });
+
+      expect(fragments.length).toBeGreaterThan(0);
+      for (const f of fragments) {
+        expect(f.fragmentType).toBe('column');
+        expect(f.isSupport).toBe(false);
+        // Column fragments should be between baseY and baseY + height
+        expect(f.worldPosition.y).toBeGreaterThanOrEqual(0.9);
+        expect(f.worldPosition.y).toBeLessThanOrEqual(4.1);
+      }
+    });
+  });
+
+  // ── Grid foundation ─────────────────────────────────────────
+
+  describe('buildGridFoundationFragments', () => {
+    it('creates a grid of support fragments', async () => {
+      const { buildGridFoundationFragments } = await import('../three/fractureBuilders');
+
+      const { fragments, foundationTopY } = buildGridFoundationFragments({
+        width: 10, depth: 10, height: 0.5,
+      });
+
+      // Should create multiple tiles
+      expect(fragments.length).toBeGreaterThan(1);
+      expect(foundationTopY).toBeCloseTo(0.501, 2); // groundClearance + height
+
+      for (const f of fragments) {
+        expect(f.isSupport).toBe(true);
+        expect(f.fragmentType).toBe('foundation');
+        expect(f.geometry).toBeInstanceOf(THREE.BufferGeometry);
+        // Should be within footprint
+        expect(Math.abs(f.worldPosition.x)).toBeLessThanOrEqual(5.01);
+        expect(Math.abs(f.worldPosition.z)).toBeLessThanOrEqual(5.01);
+      }
+    });
+
+    it('scales tile count with structure size', async () => {
+      const { buildGridFoundationFragments } = await import('../three/fractureBuilders');
+
+      const small = buildGridFoundationFragments({ width: 5, depth: 5, height: 0.2 });
+      const large = buildGridFoundationFragments({ width: 40, depth: 40, height: 0.5 });
+
+      expect(large.fragments.length).toBeGreaterThan(small.fragments.length);
+    });
+  });
+
+  // ── Bond strength multipliers ───────────────────────────────
+
+  describe('getBondStrengthMultiplier', () => {
+    it('returns correct multipliers for type pairs', async () => {
+      const { getBondStrengthMultiplier } = await import('../three/fractureBuilders');
+
+      expect(getBondStrengthMultiplier('column', 'column')).toBe(4.0);
+      expect(getBondStrengthMultiplier('column', 'wall')).toBe(2.5);
+      expect(getBondStrengthMultiplier('wall', 'column')).toBe(2.5);
+      expect(getBondStrengthMultiplier('column', 'floor')).toBe(2.5);
+      expect(getBondStrengthMultiplier('floor', 'floor')).toBe(2.0);
+      expect(getBondStrengthMultiplier('floor', 'wall')).toBe(1.5);
+      expect(getBondStrengthMultiplier('wall', 'floor')).toBe(1.5);
+      expect(getBondStrengthMultiplier('wall', 'wall')).toBe(1.0);
+      expect(getBondStrengthMultiplier(undefined, undefined)).toBe(1.0);
+      expect(getBondStrengthMultiplier('wall', undefined)).toBe(1.0);
+    });
+  });
+
+  describe('applyBondStrengthMultipliers', () => {
+    it('scales bond areas by fragment type', async () => {
+      const { applyBondStrengthMultipliers } = await import('../three/fractureBuilders');
+
+      const bonds = [
+        { node0: 0, node1: 1, centroid: { x: 0, y: 0, z: 0 }, normal: { x: 1, y: 0, z: 0 }, area: 1.0 },
+        { node0: 2, node1: 3, centroid: { x: 0, y: 0, z: 0 }, normal: { x: 0, y: 1, z: 0 }, area: 1.0 },
+        { node0: 0, node1: 2, centroid: { x: 0, y: 0, z: 0 }, normal: { x: 0, y: 0, z: 1 }, area: 1.0 },
+      ];
+      const types = ['column', 'column', 'wall', 'wall'] as const;
+
+      const result = applyBondStrengthMultipliers(bonds, [...types]);
+
+      // column-column: 4x
+      expect(result[0].area).toBe(4.0);
+      // wall-wall: 1x
+      expect(result[1].area).toBe(1.0);
+      // column-wall: 2.5x
+      expect(result[2].area).toBe(2.5);
+    });
+
+    it('preserves bonds with no type change', async () => {
+      const { applyBondStrengthMultipliers } = await import('../three/fractureBuilders');
+
+      const bond = { node0: 0, node1: 1, centroid: { x: 0, y: 0, z: 0 }, normal: { x: 1, y: 0, z: 0 }, area: 2.5 };
+      const result = applyBondStrengthMultipliers([bond], ['wall', 'wall']);
+
+      // wall-wall = 1.0x, so area unchanged; bond object identity preserved
+      expect(result[0]).toBe(bond);
+      expect(result[0].area).toBe(2.5);
+    });
+  });
+});

--- a/blast/blast-stress-solver/src/three.ts
+++ b/blast/blast-stress-solver/src/three.ts
@@ -2,6 +2,7 @@ export * from './three/autoBonding';
 export * from './three/bundle';
 export * from './three/destructible-adapter';
 export * from './three/fracture';
+export * from './three/fractureBuilders';
 export * from './three/foundation';
 export * from './three/geometryUtils';
 export * from './three/pinataFracture';

--- a/blast/blast-stress-solver/src/three/fracture.ts
+++ b/blast/blast-stress-solver/src/three/fracture.ts
@@ -10,11 +10,16 @@ import type { ScenarioBond, Vec3 } from '../rapier/types';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
+/** Fragment structural role, used for bond strength multipliers in multi-component scenarios. */
+export type FragmentType = 'column' | 'floor' | 'wall' | 'foundation';
+
 export type FragmentInfo = {
   worldPosition: Vec3;
   halfExtents: Vec3;
   geometry: THREE.BufferGeometry;
   isSupport: boolean;
+  /** Optional structural type for bond strength scaling (column > floor > wall). */
+  fragmentType?: FragmentType;
 };
 
 export type BondDetectionOptions = {

--- a/blast/blast-stress-solver/src/three/fractureBuilders.ts
+++ b/blast/blast-stress-solver/src/three/fractureBuilders.ts
@@ -1,0 +1,340 @@
+/**
+ * Reusable fragment builder functions for multi-component fractured structures.
+ *
+ * Each builder fractures a box geometry (wall panel, floor slab, column) using
+ * three-pinata Voronoi tessellation, then transforms fragments to world space.
+ * All builders produce FragmentInfo[] arrays compatible with buildScenarioFromFragments().
+ *
+ * Improvements over vibe-city's fractureUtils.ts:
+ * - Uses existing fractureGeometry() with proper pinata module management
+ * - Plain Vec3 positions (not THREE.Vector3)
+ * - Consistent geometry preparation (ensurePlainAttributes, recenterGeometry)
+ */
+import * as THREE from 'three';
+import type { Vec3, ScenarioBond } from '../rapier/types';
+import type { FragmentInfo, FragmentType } from './fracture';
+import { fractureGeometry, type FractureGeometryOptions } from './pinataFracture';
+
+// ── Fragment builders ─────────────────────────────────────────────────────
+
+export type WallFragmentOptions = {
+  /** Wall span along its local X axis (m) */
+  span: number;
+  /** Wall height along Y (m) */
+  height: number;
+  /** Wall thickness along its local Z axis (m) */
+  thickness: number;
+  /** Number of Voronoi fragments */
+  fragmentCount: number;
+  /** World X position of wall center */
+  centerX?: number;
+  /** World Z position of wall center */
+  centerZ?: number;
+  /** Rotation around Y axis (radians). 0 = wall spans X, PI/2 = wall spans Z */
+  rotationY?: number;
+  /** Y position of wall bottom edge */
+  baseY?: number;
+  /** Minimum half-extent for fragments (default: 0.05) */
+  minHalfExtent?: number;
+  /** Pre-loaded pinata module (optional) */
+  pinata?: FractureGeometryOptions['pinata'];
+};
+
+/**
+ * Fracture a wall panel and position fragments in world space.
+ *
+ * Creates a box geometry (span x height x thickness), fractures it,
+ * then applies rotation and translation to place fragments at the target position.
+ */
+export function buildWallFragments(options: WallFragmentOptions): FragmentInfo[] {
+  const {
+    span,
+    height,
+    thickness,
+    fragmentCount,
+    centerX = 0,
+    centerZ = 0,
+    rotationY = 0,
+    baseY = 0,
+    minHalfExtent = 0.05,
+    pinata,
+  } = options;
+
+  const geometry = new THREE.BoxGeometry(span, height, thickness, 2, 3, 1);
+
+  const fragments = fractureGeometry(geometry, {
+    fragmentCount,
+    worldOffset: { x: 0, y: 0, z: 0 },
+    minHalfExtent,
+    pinata,
+  });
+  geometry.dispose();
+
+  // Wall center: (centerX, baseY + height/2, centerZ)
+  const cy = height * 0.5 + baseY;
+
+  if (Math.abs(rotationY) < 0.001) {
+    // No rotation: just translate
+    return fragments.map((f) => ({
+      ...f,
+      worldPosition: {
+        x: f.worldPosition.x + centerX,
+        y: f.worldPosition.y + cy,
+        z: f.worldPosition.z + centerZ,
+      },
+      fragmentType: 'wall' as const,
+    }));
+  }
+
+  // Apply Y-axis rotation
+  const rotMatrix = new THREE.Matrix4().makeRotationY(rotationY);
+  const cos = Math.abs(Math.cos(rotationY));
+  const sin = Math.abs(Math.sin(rotationY));
+
+  return fragments.map((f) => {
+    // Rotate fragment position offset around Y
+    const v = new THREE.Vector3(f.worldPosition.x, f.worldPosition.y, f.worldPosition.z);
+    v.applyMatrix4(rotMatrix);
+
+    // Rotate geometry to match
+    f.geometry.applyMatrix4(rotMatrix);
+
+    // Recompute bounding box after rotation
+    f.geometry.computeBoundingBox();
+    const size = new THREE.Vector3();
+    (f.geometry.boundingBox as THREE.Box3).getSize(size);
+
+    return {
+      worldPosition: {
+        x: v.x + centerX,
+        y: v.y + cy,
+        z: v.z + centerZ,
+      },
+      halfExtents: {
+        x: Math.max(minHalfExtent, size.x * 0.5),
+        y: Math.max(minHalfExtent, size.y * 0.5),
+        z: Math.max(minHalfExtent, size.z * 0.5),
+      },
+      geometry: f.geometry,
+      isSupport: false,
+      fragmentType: 'wall' as const,
+    };
+  });
+}
+
+export type FloorFragmentOptions = {
+  /** Floor span along X (m) */
+  spanX: number;
+  /** Floor span along Z (m) */
+  spanZ: number;
+  /** Floor thickness along Y (m) */
+  thickness: number;
+  /** Number of Voronoi fragments */
+  fragmentCount: number;
+  /** World X position of floor center */
+  centerX?: number;
+  /** World Y position of floor center */
+  centerY?: number;
+  /** World Z position of floor center */
+  centerZ?: number;
+  /** Minimum half-extent for fragments (default: 0.05) */
+  minHalfExtent?: number;
+  /** Pre-loaded pinata module (optional) */
+  pinata?: FractureGeometryOptions['pinata'];
+};
+
+/**
+ * Fracture a horizontal floor slab and position fragments in world space.
+ */
+export function buildFloorFragments(options: FloorFragmentOptions): FragmentInfo[] {
+  const {
+    spanX,
+    spanZ,
+    thickness,
+    fragmentCount,
+    centerX = 0,
+    centerY = 0,
+    centerZ = 0,
+    minHalfExtent = 0.05,
+    pinata,
+  } = options;
+
+  const geometry = new THREE.BoxGeometry(spanX, thickness, spanZ, 3, 1, 3);
+
+  const fragments = fractureGeometry(geometry, {
+    fragmentCount,
+    worldOffset: { x: centerX, y: centerY, z: centerZ },
+    minHalfExtent,
+    pinata,
+  });
+  geometry.dispose();
+
+  return fragments.map((f) => ({
+    ...f,
+    fragmentType: 'floor' as const,
+  }));
+}
+
+export type ColumnFragmentOptions = {
+  /** Column cross-section X size (m) */
+  sizeX: number;
+  /** Column cross-section Z size (m) */
+  sizeZ: number;
+  /** Column height along Y (m) */
+  height: number;
+  /** Number of Voronoi fragments */
+  fragmentCount: number;
+  /** World X position of column center */
+  centerX?: number;
+  /** Y position of column bottom edge */
+  baseY?: number;
+  /** World Z position of column center */
+  centerZ?: number;
+  /** Minimum half-extent for fragments (default: 0.05) */
+  minHalfExtent?: number;
+  /** Pre-loaded pinata module (optional) */
+  pinata?: FractureGeometryOptions['pinata'];
+};
+
+/**
+ * Fracture a vertical column and position fragments in world space.
+ */
+export function buildColumnFragments(options: ColumnFragmentOptions): FragmentInfo[] {
+  const {
+    sizeX,
+    sizeZ,
+    height,
+    fragmentCount,
+    centerX = 0,
+    baseY = 0,
+    centerZ = 0,
+    minHalfExtent = 0.05,
+    pinata,
+  } = options;
+
+  const geometry = new THREE.BoxGeometry(sizeX, height, sizeZ, 1, 3, 1);
+
+  // Column center is at baseY + height/2
+  const cy = baseY + height * 0.5;
+  const fragments = fractureGeometry(geometry, {
+    fragmentCount,
+    worldOffset: { x: centerX, y: cy, z: centerZ },
+    minHalfExtent,
+    pinata,
+  });
+  geometry.dispose();
+
+  return fragments.map((f) => ({
+    ...f,
+    fragmentType: 'column' as const,
+  }));
+}
+
+// ── Grid foundation ───────────────────────────────────────────────────────
+
+export type GridFoundationOptions = {
+  /** Foundation footprint width (X) in meters */
+  width: number;
+  /** Foundation footprint depth (Z) in meters */
+  depth: number;
+  /** Foundation height (Y) in meters */
+  height: number;
+  /** Gap between foundation bottom and ground plane (default: 0.001) */
+  groundClearance?: number;
+  /** Target tile size for foundation grid. Auto-calculated if omitted (~6-8 tiles per side). */
+  tileSize?: number;
+};
+
+/**
+ * Create a 2D grid of support tile fragments forming a rectangular foundation.
+ *
+ * Each tile is a simple box geometry with isSupport=true (mass=0 in the solver).
+ * The tile count scales with structure size to maintain reasonable coverage.
+ *
+ * @returns Array of support FragmentInfo and the Y coordinate of the foundation top surface.
+ */
+export function buildGridFoundationFragments(
+  options: GridFoundationOptions,
+): { fragments: FragmentInfo[]; foundationTopY: number } {
+  const {
+    width,
+    depth,
+    height,
+    groundClearance = 0.001,
+  } = options;
+
+  const tileSize = options.tileSize ?? Math.max(1.0, Math.min(width, depth) / 6);
+  const segmentsX = Math.max(4, Math.round(width / tileSize));
+  const segmentsZ = Math.max(4, Math.round(depth / tileSize));
+  const cellW = width / segmentsX;
+  const cellD = depth / segmentsZ;
+
+  const halfWidth = width * 0.5;
+  const halfDepth = depth * 0.5;
+  const foundationTopY = groundClearance + height;
+
+  const fragments: FragmentInfo[] = [];
+  for (let ix = 0; ix < segmentsX; ix++) {
+    for (let iz = 0; iz < segmentsZ; iz++) {
+      const cx = -halfWidth + cellW * (ix + 0.5);
+      const cz = -halfDepth + cellD * (iz + 0.5);
+      const cy = groundClearance + height * 0.5;
+
+      fragments.push({
+        worldPosition: { x: cx, y: cy, z: cz },
+        halfExtents: { x: cellW * 0.5, y: height * 0.5, z: cellD * 0.5 },
+        geometry: new THREE.BoxGeometry(cellW, height, cellD),
+        isSupport: true,
+        fragmentType: 'foundation' as const,
+      });
+    }
+  }
+
+  return { fragments, foundationTopY };
+}
+
+// ── Bond strength multipliers ─────────────────────────────────────────────
+
+/**
+ * Bond strength multiplier based on the structural roles of the two connected fragments.
+ *
+ * Strength hierarchy (strongest to weakest):
+ * 1. column-column: 4.0x  (primary load-bearing)
+ * 2. column-anything: 2.5x (column connections)
+ * 3. floor-floor: 2.0x     (slab continuity)
+ * 4. floor-wall: 1.5x      (wall-to-slab joints)
+ * 5. wall-wall: 1.0x       (baseline)
+ */
+export function getBondStrengthMultiplier(
+  type0: FragmentType | undefined,
+  type1: FragmentType | undefined,
+): number {
+  if (type0 === 'column' && type1 === 'column') return 4.0;
+  if (type0 === 'column' || type1 === 'column') return 2.5;
+  if (type0 === 'floor' && type1 === 'floor') return 2.0;
+  if ((type0 === 'floor' && type1 === 'wall') || (type0 === 'wall' && type1 === 'floor')) return 1.5;
+  return 1.0;
+}
+
+/**
+ * Apply type-based bond strength multipliers by scaling bond areas.
+ *
+ * Larger area → lower stress → harder to break, so multiplying the area
+ * of column-column bonds by 4x makes them 4x stronger than wall-wall bonds.
+ *
+ * @param bonds - The bond array to modify (mutated in place and returned)
+ * @param fragmentTypes - Per-node fragment type array (indexed by node index)
+ */
+export function applyBondStrengthMultipliers(
+  bonds: ScenarioBond[],
+  fragmentTypes: (FragmentType | undefined)[],
+): ScenarioBond[] {
+  return bonds.map((bond) => {
+    const multiplier = getBondStrengthMultiplier(
+      fragmentTypes[bond.node0],
+      fragmentTypes[bond.node1],
+    );
+    if (multiplier === 1.0) return bond;
+    return { ...bond, area: bond.area * multiplier };
+  });
+}

--- a/blast/js_stress_example/demo-index.html
+++ b/blast/js_stress_example/demo-index.html
@@ -126,6 +126,26 @@
         <span class="tag new">NEW — fracture + rapier + three</span>
       </a>
 
+      <a class="card" href="./fractured-tower.html">
+        <div class="card-icon">&#127959;</div>
+        <h2>Fractured Tower</h2>
+        <p>
+          Multi-floor tower with Voronoi-fractured walls, interior columns, floor plates,
+          and foundation. Type-based bond strength multipliers for realistic progressive collapse.
+        </p>
+        <span class="tag new">NEW — fracture + rapier + three</span>
+      </a>
+
+      <a class="card" href="./fractured-bridge.html">
+        <div class="card-icon">&#127753;</div>
+        <h2>Fractured Bridge</h2>
+        <p>
+          Beam bridge with fractured deck slab and support posts on footing supports.
+          Irregular Voronoi fragments with proximity-based bond detection.
+        </p>
+        <span class="tag new">NEW — fracture + rapier + three</span>
+      </a>
+
       <a class="card" href="./fracture-policy.html">
         <div class="card-icon">&#9881;</div>
         <h2>Fracture Policy</h2>

--- a/blast/js_stress_example/fractured-bridge.html
+++ b/blast/js_stress_example/fractured-bridge.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fractured Bridge — blast-stress-solver Demo</title>
+    <link rel="stylesheet" href="./styles/demo-common.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "/vendor/three/build/three.module.js",
+          "three/addons/": "/vendor/three/examples/jsm/",
+          "@dimforge/rapier3d-compat": "/vendor/rapier/rapier.mjs",
+          "@dgreenheck/three-pinata": "/vendor/three-pinata/three-pinata.es.js",
+          "blast-stress-solver": "/vendor/blast-stress-solver/index.js",
+          "blast-stress-solver/rapier": "/vendor/blast-stress-solver/rapier.js",
+          "blast-stress-solver/three": "/vendor/blast-stress-solver/three.js",
+          "blast-stress-solver/scenarios": "/vendor/blast-stress-solver/scenarios.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <main class="layout">
+      <section class="viewport">
+        <canvas id="demo-canvas"></canvas>
+        <div class="viewport-hint">Click to shoot projectiles</div>
+      </section>
+
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle settings panel">
+        <span class="icon-open">&#9776;</span>
+        <span class="icon-close">&#10005;</span>
+      </button>
+      <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
+
+      <aside class="sidebar" id="sidebar">
+        <header>
+          <a href="./demo-index.html" class="back-link">&larr; All Demos</a>
+          <h1>&#127753; Fractured Bridge</h1>
+          <p>Voronoi-fractured beam bridge with destructible deck and support posts</p>
+        </header>
+
+        <!-- Bridge Config (deferred – needs Reset) -->
+        <section class="config-section">
+          <h2 class="section-title">Bridge (Reset to apply)</h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-span">Span</label>
+            <input type="range" id="cfg-span" class="config-slider" min="6" max="30" step="1" value="12" />
+            <span class="config-value"><span id="cfg-span-value">12</span> m</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-deck-width">Deck Width</label>
+            <input type="range" id="cfg-deck-width" class="config-slider" min="2" max="8" step="0.5" value="4" />
+            <span class="config-value"><span id="cfg-deck-width-value">4</span> m</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-pier-height">Pier Height</label>
+            <input type="range" id="cfg-pier-height" class="config-slider" min="1" max="8" step="0.5" value="2.8" />
+            <span class="config-value"><span id="cfg-pier-height-value">2.8</span> m</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-supports">Supports / Side</label>
+            <input type="range" id="cfg-supports" class="config-slider" min="2" max="8" step="1" value="4" />
+            <span class="config-value"><span id="cfg-supports-value">4</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-deck-frags">Deck Fragments</label>
+            <input type="range" id="cfg-deck-frags" class="config-slider" min="8" max="80" step="2" value="25" />
+            <span class="config-value"><span id="cfg-deck-frags-value">25</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-post-frags">Post Fragments</label>
+            <input type="range" id="cfg-post-frags" class="config-slider" min="2" max="10" step="1" value="4" />
+            <span class="config-value"><span id="cfg-post-frags-value">4</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-total-mass">Total Mass</label>
+            <input type="range" id="cfg-total-mass" class="config-slider" min="5000" max="120000" step="5000" value="30000" />
+            <span class="config-value"><span id="cfg-total-mass-value">30,000</span> kg</span>
+          </div>
+        </section>
+
+        <!-- Projectile (immediate) -->
+        <section class="config-section">
+          <h2 class="section-title">Projectile</h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-proj-radius">Radius</label>
+            <input type="range" id="cfg-proj-radius" class="config-slider" min="0.1" max="1.5" step="0.05" value="0.4" />
+            <span class="config-value"><span id="cfg-proj-radius-value">0.40</span> m</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-proj-mass">Mass</label>
+            <input type="range" id="cfg-proj-mass" class="config-slider" min="1000" max="80000" step="1000" value="15000" />
+            <span class="config-value"><span id="cfg-proj-mass-value">15,000</span> kg</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-proj-speed">Speed</label>
+            <input type="range" id="cfg-proj-speed" class="config-slider" min="5" max="60" step="1" value="20" />
+            <span class="config-value"><span id="cfg-proj-speed-value">20</span> m/s</span>
+          </div>
+        </section>
+
+        <!-- Solver (deferred) -->
+        <section class="config-section">
+          <h2 class="section-title">Solver (Reset to apply)</h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-gravity">Gravity</label>
+            <input type="range" id="cfg-gravity" class="config-slider" min="-30" max="0" step="0.5" value="-9.81" />
+            <span class="config-value"><span id="cfg-gravity-value">-9.8</span> m/s&sup2;</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-material">Material Scale</label>
+            <input type="range" id="cfg-material" class="config-slider" min="2" max="10" step="0.1" value="8" />
+            <span class="config-value"><span id="cfg-material-value">1e8</span></span>
+          </div>
+        </section>
+
+        <!-- Physics -->
+        <section class="config-section">
+          <h2 class="section-title">Physics <small style="font-weight:normal;opacity:.5">&#9733; = live</small></h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-debris-collision">Debris Collision &#9733;</label>
+            <select id="cfg-debris-collision" class="config-select">
+              <option value="all" selected>All (full collisions)</option>
+              <option value="noDebrisPairs">No debris pairs</option>
+              <option value="debrisGroundOnly">Debris &harr; ground only</option>
+              <option value="debrisNone">Debris: none</option>
+            </select>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-friction">Friction</label>
+            <input type="range" id="cfg-friction" class="config-slider" min="0" max="2" step="0.05" value="0.25" />
+            <span class="config-value"><span id="cfg-friction-value">0.25</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-restitution">Restitution</label>
+            <input type="range" id="cfg-restitution" class="config-slider" min="0" max="1" step="0.05" value="0.00" />
+            <span class="config-value"><span id="cfg-restitution-value">0.00</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-contact-force">Contact Force Scale</label>
+            <input type="range" id="cfg-contact-force" class="config-slider" min="1" max="100" step="1" value="30" />
+            <span class="config-value"><span id="cfg-contact-force-value">30</span></span>
+          </div>
+        </section>
+
+        <!-- Optimization -->
+        <section class="config-section">
+          <h2 class="section-title">Optimization <small style="font-weight:normal;opacity:.5">&#9733; = live</small></h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-damping-mode">Small Body Damping &#9733;</label>
+            <select id="cfg-damping-mode" class="config-select">
+              <option value="off">Off</option>
+              <option value="always" selected>Always</option>
+              <option value="afterGroundCollision">After ground hit</option>
+            </select>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-cleanup-mode">Debris Cleanup &#9733;</label>
+            <select id="cfg-cleanup-mode" class="config-select">
+              <option value="off">Off</option>
+              <option value="always" selected>Always</option>
+              <option value="afterGroundCollision">After ground hit</option>
+            </select>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-debris-ttl">Debris TTL</label>
+            <input type="range" id="cfg-debris-ttl" class="config-slider" min="1000" max="30000" step="500" value="10000" />
+            <span class="config-value"><span id="cfg-debris-ttl-value">10.0s</span></span>
+          </div>
+        </section>
+
+        <!-- Actions -->
+        <div class="control-actions">
+          <button id="btn-reset" class="button button-primary">&orarr; Reset Bridge</button>
+          <button id="btn-debug" class="button">&#9671; Show Debug</button>
+        </div>
+
+        <!-- Status -->
+        <section class="status-panel">
+          <h2>Simulation</h2>
+          <div class="status-grid">
+            <div class="status-item"><span class="status-label">Bodies</span><span class="status-value" id="stat-bodies">0</span></div>
+            <div class="status-item"><span class="status-label">Bonds</span><span class="status-value" id="stat-bonds">0</span></div>
+            <div class="status-item"><span class="status-label">Fragments</span><span class="status-value" id="stat-fragments">0</span></div>
+            <div class="status-item"><span class="status-label">Projectiles</span><span class="status-value" id="stat-projectiles">0</span></div>
+            <div class="status-item"><span class="status-label">Chunks</span><span class="status-value" id="stat-chunks">0</span></div>
+          </div>
+        </section>
+
+        <!-- Performance -->
+        <section class="status-panel">
+          <h2>Performance</h2>
+          <div class="status-grid">
+            <div class="status-item"><span class="status-label">Physics</span><span class="status-value" id="stat-physics-ms">&mdash; ms</span></div>
+            <div class="status-item"><span class="status-label">Render</span><span class="status-value" id="stat-render-ms">&mdash; ms</span></div>
+            <div class="status-item"><span class="status-label">Draw Calls</span><span class="status-value" id="stat-draw-calls">0</span></div>
+            <div class="status-item"><span class="status-label">Triangles</span><span class="status-value" id="stat-triangles">0</span></div>
+          </div>
+        </section>
+      </aside>
+    </main>
+
+    <script>
+      (function () {
+        var toggle = document.getElementById('sidebar-toggle');
+        var sidebar = document.getElementById('sidebar');
+        var backdrop = document.getElementById('sidebar-backdrop');
+        var layout = document.querySelector('.layout');
+        var mql = window.matchMedia('(max-width: 768px)');
+        function isMobile() { return mql.matches; }
+        function close() { toggle.classList.remove('active'); if (isMobile()) { sidebar.classList.remove('open'); backdrop.classList.remove('visible'); } else { layout.classList.add('sidebar-hidden'); } }
+        function open() { toggle.classList.add('active'); if (isMobile()) { sidebar.classList.add('open'); backdrop.classList.add('visible'); } else { layout.classList.remove('sidebar-hidden'); } }
+        function isOpen() { return isMobile() ? sidebar.classList.contains('open') : !layout.classList.contains('sidebar-hidden'); }
+        toggle.addEventListener('click', function () { if (isOpen()) close(); else open(); });
+        backdrop.addEventListener('click', close);
+        if (!isMobile()) toggle.classList.add('active');
+      })();
+    </script>
+    <script type="module" src="./dist/fractured-bridge.js"></script>
+  </body>
+</html>

--- a/blast/js_stress_example/fractured-bridge.ts
+++ b/blast/js_stress_example/fractured-bridge.ts
@@ -16,12 +16,8 @@ import { buildDestructibleCore } from 'blast-stress-solver/rapier';
 import {
   createDestructibleThreeBundle,
   RapierDebugRenderer,
-  setPinataModule,
 } from 'blast-stress-solver/three';
 import { buildFracturedBridgeScenario } from 'blast-stress-solver/scenarios';
-
-// Register pinata module for browser ESM
-setPinataModule(pinata as any);
 
 // ── Config ────────────────────────────────────────────────────
 
@@ -168,6 +164,7 @@ async function initScene() {
     fragmentCountPerDeck: CONFIG.bridge.fragmentCountPerDeck,
     fragmentCountPerPost: CONFIG.bridge.fragmentCountPerPost,
     deckMass: CONFIG.bridge.deckMass,
+    pinata: pinata as any,
   });
 
   console.log(

--- a/blast/js_stress_example/fractured-bridge.ts
+++ b/blast/js_stress_example/fractured-bridge.ts
@@ -1,0 +1,366 @@
+/**
+ * Fractured Bridge Demo
+ *
+ * Beam bridge with Voronoi-fractured deck slab and support posts.
+ * Uses three-pinata for irregular fragment generation and the
+ * blast-stress-solver runtime for stress-driven destruction.
+ *
+ * Click the viewport to launch projectiles at the bridge.
+ */
+
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import Stats from 'three/addons/libs/stats.module.js';
+import * as pinata from '@dgreenheck/three-pinata';
+import { buildDestructibleCore } from 'blast-stress-solver/rapier';
+import {
+  createDestructibleThreeBundle,
+  RapierDebugRenderer,
+  setPinataModule,
+} from 'blast-stress-solver/three';
+import { buildFracturedBridgeScenario } from 'blast-stress-solver/scenarios';
+
+// Register pinata module for browser ESM
+setPinataModule(pinata as any);
+
+// ── Config ────────────────────────────────────────────────────
+
+const CONFIG = {
+  bridge: {
+    span: 12,
+    deckWidth: 4,
+    deckThickness: 0.5,
+    pierHeight: 2.8,
+    supportsPerSide: 4,
+    postSize: 0.4,
+    fragmentCountPerDeck: 25,
+    fragmentCountPerPost: 4,
+    deckMass: 30_000,
+  },
+  projectile: {
+    radius: 0.4,
+    mass: 15_000,
+    speed: 20,
+  },
+  solver: {
+    gravity: -9.81,
+    materialScale: 1e8,
+  },
+  physics: {
+    debrisCollisionMode: 'all' as string,
+    friction: 0.25,
+    restitution: 0.0,
+    contactForceScale: 30,
+  },
+  optimization: {
+    smallBodyDampingMode: 'always' as string,
+    debrisCleanupMode: 'always' as string,
+    debrisTtlMs: 10000,
+    maxCollidersForDebris: 2,
+  },
+};
+
+// ── Three.js setup ────────────────────────────────────────────
+
+const canvas = document.getElementById('demo-canvas') as HTMLCanvasElement;
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x0a0d13);
+scene.fog = new THREE.FogExp2(0x0a0d13, 0.015);
+
+const camera = new THREE.PerspectiveCamera(
+  55,
+  canvas.clientWidth / canvas.clientHeight,
+  0.1,
+  300,
+);
+camera.position.set(0, 6, 18);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 2.5, 0);
+controls.enableDamping = true;
+controls.dampingFactor = 0.08;
+controls.update();
+
+// Lights
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.4);
+scene.add(ambientLight);
+
+const dirLight = new THREE.DirectionalLight(0xffeedd, 1.0);
+dirLight.position.set(10, 16, 12);
+dirLight.castShadow = true;
+dirLight.shadow.mapSize.set(2048, 2048);
+dirLight.shadow.camera.left = -20;
+dirLight.shadow.camera.right = 20;
+dirLight.shadow.camera.top = 15;
+dirLight.shadow.camera.bottom = -5;
+scene.add(dirLight);
+
+// Ground plane
+const groundGeo = new THREE.PlaneGeometry(80, 80);
+const groundMat = new THREE.MeshStandardMaterial({
+  color: 0x1a1e2f,
+  roughness: 0.85,
+  metalness: 0.1,
+});
+const groundMesh = new THREE.Mesh(groundGeo, groundMat);
+groundMesh.rotation.x = -Math.PI / 2;
+groundMesh.position.y = -0.35;
+groundMesh.receiveShadow = true;
+scene.add(groundMesh);
+
+// ── Stats panel ──────────────────────────────────────────────
+
+const stats = new Stats();
+stats.dom.style.position = 'absolute';
+stats.dom.style.top = '0';
+stats.dom.style.left = '0';
+(document.querySelector('.viewport') as HTMLElement)?.appendChild(stats.dom);
+
+// ── Perf tracking ────────────────────────────────────────────
+
+let _physicsMs = 0;
+let _renderMs = 0;
+const EMA = 0.12;
+
+function updatePerfStats() {
+  const el = (id: string) => document.getElementById(id);
+  el('stat-physics-ms')!.textContent = _physicsMs.toFixed(1) + ' ms';
+  el('stat-render-ms')!.textContent = _renderMs.toFixed(1) + ' ms';
+  el('stat-draw-calls')!.textContent = String(renderer.info.render.calls);
+  el('stat-triangles')!.textContent = renderer.info.render.triangles.toLocaleString();
+}
+
+function updateStatus(core: any) {
+  const el = (id: string) => document.getElementById(id);
+  el('stat-bodies')!.textContent = String(core.getRigidBodyCount());
+  el('stat-bonds')!.textContent = String(core.getActiveBondsCount());
+  el('stat-projectiles')!.textContent = String(core.projectiles.length);
+  const active = core.chunks.filter((c: any) => c.active).length;
+  const detached = core.chunks.filter((c: any) => c.detached).length;
+  el('stat-chunks')!.textContent = `${active} / ${detached} detached`;
+  el('stat-fragments')!.textContent = String(core.chunks.length);
+}
+
+// ── Main ─────────────────────────────────────────────────────
+
+let coreRef: Awaited<ReturnType<typeof buildDestructibleCore>> | null = null;
+let visualsRef: ReturnType<typeof createDestructibleThreeBundle> | null = null;
+let rapierDebug: RapierDebugRenderer | null = null;
+let showDebug = false;
+
+async function initScene() {
+  const hint = document.querySelector('.viewport-hint') as HTMLElement;
+  if (hint) hint.textContent = 'Building bridge...';
+
+  const scenario = await buildFracturedBridgeScenario({
+    span: CONFIG.bridge.span,
+    deckWidth: CONFIG.bridge.deckWidth,
+    deckThickness: CONFIG.bridge.deckThickness,
+    pierHeight: CONFIG.bridge.pierHeight,
+    supportsPerSide: CONFIG.bridge.supportsPerSide,
+    postSize: CONFIG.bridge.postSize,
+    fragmentCountPerDeck: CONFIG.bridge.fragmentCountPerDeck,
+    fragmentCountPerPost: CONFIG.bridge.fragmentCountPerPost,
+    deckMass: CONFIG.bridge.deckMass,
+  });
+
+  console.log(
+    `Fractured bridge: ${scenario.nodes.length} nodes, ${scenario.bonds.length} bonds`,
+  );
+
+  const core = await buildDestructibleCore({
+    scenario,
+    gravity: CONFIG.solver.gravity,
+    materialScale: CONFIG.solver.materialScale,
+    friction: CONFIG.physics.friction,
+    restitution: CONFIG.physics.restitution,
+    contactForceScale: CONFIG.physics.contactForceScale,
+    debrisCollisionMode: CONFIG.physics.debrisCollisionMode as any,
+    damage: { enabled: false },
+    debrisCleanup: {
+      mode: CONFIG.optimization.debrisCleanupMode as any,
+      debrisTtlMs: CONFIG.optimization.debrisTtlMs,
+      maxCollidersForDebris: CONFIG.optimization.maxCollidersForDebris,
+    },
+    smallBodyDamping: {
+      mode: CONFIG.optimization.smallBodyDampingMode as any,
+      colliderCountThreshold: 3,
+      minLinearDamping: 2,
+      minAngularDamping: 2,
+    },
+  });
+
+  const group = new THREE.Group();
+  scene.add(group);
+
+  const visuals = createDestructibleThreeBundle({
+    core,
+    scenario,
+    root: group,
+    useBatchedMesh: true,
+    batchedMeshOptions: { enableBVH: false, bvhMargin: 5 },
+    includeDebugLines: true,
+  });
+
+  rapierDebug?.dispose();
+  rapierDebug = new RapierDebugRenderer(scene, core.world as any, { enabled: showDebug });
+
+  coreRef = core;
+  visualsRef = visuals;
+
+  if (hint) hint.textContent = 'Click to shoot projectiles';
+}
+
+// ── Projectile shooting ──────────────────────────────────────
+
+function shootProjectile(ndcX: number, ndcY: number) {
+  const core = coreRef;
+  if (!core) return;
+  const raycaster = new THREE.Raycaster();
+  raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
+  const dir = raycaster.ray.direction.clone().normalize();
+  core.enqueueProjectile({
+    position: { x: camera.position.x, y: camera.position.y, z: camera.position.z },
+    velocity: { x: dir.x * CONFIG.projectile.speed, y: dir.y * CONFIG.projectile.speed, z: dir.z * CONFIG.projectile.speed },
+    radius: CONFIG.projectile.radius,
+    mass: CONFIG.projectile.mass,
+    ttl: 6000,
+  });
+}
+
+canvas.addEventListener('click', (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const ndcX = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+  const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+  shootProjectile(ndcX, ndcY);
+});
+
+// ── UI wiring ────────────────────────────────────────────────
+
+document.getElementById('btn-reset')?.addEventListener('click', async () => {
+  visualsRef?.dispose();
+  coreRef?.dispose();
+  coreRef = null;
+  visualsRef = null;
+  await initScene();
+});
+
+document.getElementById('btn-debug')?.addEventListener('click', () => {
+  showDebug = !showDebug;
+  rapierDebug?.setEnabled(showDebug);
+  const btn = document.getElementById('btn-debug')!;
+  btn.textContent = showDebug ? '\u25C8 Hide Debug' : '\u25C7 Show Debug';
+});
+
+function bindSlider(id: string, obj: Record<string, any>, key: string, fmt?: (v: number) => string) {
+  const slider = document.getElementById(id) as HTMLInputElement | null;
+  const display = document.getElementById(id + '-value');
+  if (!slider) return;
+  slider.value = String(obj[key]);
+  if (display) display.textContent = fmt ? fmt(obj[key]) : String(obj[key]);
+  slider.addEventListener('input', () => {
+    const v = parseFloat(slider.value);
+    obj[key] = v;
+    if (display) display.textContent = fmt ? fmt(v) : String(v);
+  });
+}
+
+function bindSelect(id: string, obj: Record<string, any>, key: string, onChange?: (v: string) => void) {
+  const select = document.getElementById(id) as HTMLSelectElement | null;
+  if (!select) return;
+  select.value = String(obj[key]);
+  select.addEventListener('change', () => { obj[key] = select.value; onChange?.(select.value); });
+}
+
+// Bridge config (deferred)
+bindSlider('cfg-span', CONFIG.bridge, 'span');
+bindSlider('cfg-deck-width', CONFIG.bridge, 'deckWidth');
+bindSlider('cfg-pier-height', CONFIG.bridge, 'pierHeight');
+bindSlider('cfg-supports', CONFIG.bridge, 'supportsPerSide');
+bindSlider('cfg-deck-frags', CONFIG.bridge, 'fragmentCountPerDeck');
+bindSlider('cfg-post-frags', CONFIG.bridge, 'fragmentCountPerPost');
+bindSlider('cfg-total-mass', CONFIG.bridge, 'deckMass', (v) => v.toLocaleString());
+
+// Projectile
+bindSlider('cfg-proj-radius', CONFIG.projectile, 'radius', (v) => v.toFixed(2));
+bindSlider('cfg-proj-mass', CONFIG.projectile, 'mass', (v) => v.toLocaleString());
+bindSlider('cfg-proj-speed', CONFIG.projectile, 'speed', (v) => v.toFixed(0));
+
+// Solver
+bindSlider('cfg-gravity', CONFIG.solver, 'gravity', (v) => v.toFixed(1));
+{
+  const slider = document.getElementById('cfg-material') as HTMLInputElement | null;
+  const display = document.getElementById('cfg-material-value');
+  if (slider) {
+    const exp = Math.log10(CONFIG.solver.materialScale);
+    slider.value = String(exp);
+    if (display) display.textContent = `1e${exp.toFixed(0)}`;
+    slider.addEventListener('input', () => {
+      const e = parseFloat(slider.value);
+      CONFIG.solver.materialScale = Math.pow(10, e);
+      if (display) display.textContent = `1e${e.toFixed(1)}`;
+    });
+  }
+}
+
+// Physics (live)
+bindSelect('cfg-debris-collision', CONFIG.physics, 'debrisCollisionMode', (v) => { coreRef?.setDebrisCollisionMode(v as any); });
+bindSlider('cfg-friction', CONFIG.physics, 'friction', (v) => v.toFixed(2));
+bindSlider('cfg-restitution', CONFIG.physics, 'restitution', (v) => v.toFixed(2));
+bindSlider('cfg-contact-force', CONFIG.physics, 'contactForceScale', (v) => v.toFixed(0));
+
+// Optimization (live)
+bindSelect('cfg-damping-mode', CONFIG.optimization, 'smallBodyDampingMode', (v) => { coreRef?.setSmallBodyDamping?.({ mode: v as any }); });
+bindSelect('cfg-cleanup-mode', CONFIG.optimization, 'debrisCleanupMode', (v) => { coreRef?.setDebrisCleanup?.({ mode: v as any, debrisTtlMs: CONFIG.optimization.debrisTtlMs }); });
+bindSlider('cfg-debris-ttl', CONFIG.optimization, 'debrisTtlMs', (v) => (v / 1000).toFixed(1) + 's');
+
+// ── Render loop ──────────────────────────────────────────────
+
+const clock = new THREE.Clock();
+
+function loop() {
+  requestAnimationFrame(loop);
+  stats.begin();
+  const dt = Math.min(clock.getDelta(), 1 / 30);
+  controls.update();
+
+  if (coreRef && visualsRef) {
+    const t0 = performance.now();
+    coreRef.step(dt);
+    _physicsMs += ((performance.now() - t0) - _physicsMs) * EMA;
+    visualsRef.update({ debug: showDebug, updateBVH: false, updateProjectiles: true });
+    rapierDebug?.update();
+    updateStatus(coreRef);
+  }
+
+  const t1 = performance.now();
+  renderer.render(scene, camera);
+  _renderMs += ((performance.now() - t1) - _renderMs) * EMA;
+  updatePerfStats();
+  stats.end();
+}
+
+// ── Resize ───────────────────────────────────────────────────
+
+function onResize() {
+  const w = canvas.clientWidth;
+  const h = canvas.clientHeight;
+  renderer.setSize(w, h, false);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener('resize', onResize);
+
+// ── Boot ─────────────────────────────────────────────────────
+
+initScene().then(() => loop()).catch((err) => {
+  console.error('Failed to initialize fractured bridge demo:', err);
+  const hint = document.querySelector('.viewport-hint');
+  if (hint) hint.textContent = `Error: ${err.message}`;
+});

--- a/blast/js_stress_example/fractured-tower.html
+++ b/blast/js_stress_example/fractured-tower.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fractured Tower — blast-stress-solver Demo</title>
+    <link rel="stylesheet" href="./styles/demo-common.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "/vendor/three/build/three.module.js",
+          "three/addons/": "/vendor/three/examples/jsm/",
+          "@dimforge/rapier3d-compat": "/vendor/rapier/rapier.mjs",
+          "@dgreenheck/three-pinata": "/vendor/three-pinata/three-pinata.es.js",
+          "blast-stress-solver": "/vendor/blast-stress-solver/index.js",
+          "blast-stress-solver/rapier": "/vendor/blast-stress-solver/rapier.js",
+          "blast-stress-solver/three": "/vendor/blast-stress-solver/three.js",
+          "blast-stress-solver/scenarios": "/vendor/blast-stress-solver/scenarios.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <main class="layout">
+      <section class="viewport">
+        <canvas id="demo-canvas"></canvas>
+        <div class="viewport-hint">Click to shoot projectiles</div>
+      </section>
+
+      <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle settings panel">
+        <span class="icon-open">&#9776;</span>
+        <span class="icon-close">&#10005;</span>
+      </button>
+      <div class="sidebar-backdrop" id="sidebar-backdrop"></div>
+
+      <aside class="sidebar" id="sidebar">
+        <header>
+          <a href="./demo-index.html" class="back-link">&larr; All Demos</a>
+          <h1>&#127959; Fractured Tower</h1>
+          <p>Multi-floor tower with Voronoi-fractured walls, columns, and floor plates</p>
+        </header>
+
+        <!-- Tower Config (deferred – needs Reset) -->
+        <section class="config-section">
+          <h2 class="section-title">Tower (Reset to apply)</h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-width">Width / Depth</label>
+            <input type="range" id="cfg-width" class="config-slider" min="4" max="20" step="1" value="8" />
+            <span class="config-value"><span id="cfg-width-value">8</span> m</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-floors">Floors</label>
+            <input type="range" id="cfg-floors" class="config-slider" min="1" max="10" step="1" value="4" />
+            <span class="config-value"><span id="cfg-floors-value">4</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-floor-height">Floor Height</label>
+            <input type="range" id="cfg-floor-height" class="config-slider" min="2" max="6" step="0.5" value="3" />
+            <span class="config-value"><span id="cfg-floor-height-value">3</span> m</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-wall-frags">Wall Fragments</label>
+            <input type="range" id="cfg-wall-frags" class="config-slider" min="3" max="20" step="1" value="6" />
+            <span class="config-value"><span id="cfg-wall-frags-value">6</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-floor-frags">Floor Fragments</label>
+            <input type="range" id="cfg-floor-frags" class="config-slider" min="3" max="16" step="1" value="6" />
+            <span class="config-value"><span id="cfg-floor-frags-value">6</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-total-mass">Total Mass</label>
+            <input type="range" id="cfg-total-mass" class="config-slider" min="5000" max="200000" step="5000" value="20000" />
+            <span class="config-value"><span id="cfg-total-mass-value">20,000</span> kg</span>
+          </div>
+        </section>
+
+        <!-- Projectile (immediate) -->
+        <section class="config-section">
+          <h2 class="section-title">Projectile</h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-proj-radius">Radius</label>
+            <input type="range" id="cfg-proj-radius" class="config-slider" min="0.1" max="2.0" step="0.05" value="0.5" />
+            <span class="config-value"><span id="cfg-proj-radius-value">0.50</span> m</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-proj-mass">Mass</label>
+            <input type="range" id="cfg-proj-mass" class="config-slider" min="1000" max="100000" step="1000" value="20000" />
+            <span class="config-value"><span id="cfg-proj-mass-value">20,000</span> kg</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-proj-speed">Speed</label>
+            <input type="range" id="cfg-proj-speed" class="config-slider" min="5" max="80" step="1" value="25" />
+            <span class="config-value"><span id="cfg-proj-speed-value">25</span> m/s</span>
+          </div>
+        </section>
+
+        <!-- Solver (deferred) -->
+        <section class="config-section">
+          <h2 class="section-title">Solver (Reset to apply)</h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-gravity">Gravity</label>
+            <input type="range" id="cfg-gravity" class="config-slider" min="-30" max="0" step="0.5" value="-9.81" />
+            <span class="config-value"><span id="cfg-gravity-value">-9.8</span> m/s&sup2;</span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-material">Material Scale</label>
+            <input type="range" id="cfg-material" class="config-slider" min="2" max="10" step="0.1" value="8" />
+            <span class="config-value"><span id="cfg-material-value">1e8</span></span>
+          </div>
+        </section>
+
+        <!-- Physics -->
+        <section class="config-section">
+          <h2 class="section-title">Physics <small style="font-weight:normal;opacity:.5">&#9733; = live</small></h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-debris-collision">Debris Collision &#9733;</label>
+            <select id="cfg-debris-collision" class="config-select">
+              <option value="all">All (full collisions)</option>
+              <option value="noDebrisPairs" selected>No debris pairs</option>
+              <option value="debrisGroundOnly">Debris &harr; ground only</option>
+              <option value="debrisNone">Debris: none</option>
+            </select>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-friction">Friction</label>
+            <input type="range" id="cfg-friction" class="config-slider" min="0" max="2" step="0.05" value="0.25" />
+            <span class="config-value"><span id="cfg-friction-value">0.25</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-restitution">Restitution</label>
+            <input type="range" id="cfg-restitution" class="config-slider" min="0" max="1" step="0.05" value="0.00" />
+            <span class="config-value"><span id="cfg-restitution-value">0.00</span></span>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-contact-force">Contact Force Scale</label>
+            <input type="range" id="cfg-contact-force" class="config-slider" min="1" max="100" step="1" value="30" />
+            <span class="config-value"><span id="cfg-contact-force-value">30</span></span>
+          </div>
+        </section>
+
+        <!-- Optimization -->
+        <section class="config-section">
+          <h2 class="section-title">Optimization <small style="font-weight:normal;opacity:.5">&#9733; = live</small></h2>
+          <div class="config-row">
+            <label class="config-label" for="cfg-damping-mode">Small Body Damping &#9733;</label>
+            <select id="cfg-damping-mode" class="config-select">
+              <option value="off">Off</option>
+              <option value="always" selected>Always</option>
+              <option value="afterGroundCollision">After ground hit</option>
+            </select>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-cleanup-mode">Debris Cleanup &#9733;</label>
+            <select id="cfg-cleanup-mode" class="config-select">
+              <option value="off">Off</option>
+              <option value="always" selected>Always</option>
+              <option value="afterGroundCollision">After ground hit</option>
+            </select>
+          </div>
+          <div class="config-row">
+            <label class="config-label" for="cfg-debris-ttl">Debris TTL</label>
+            <input type="range" id="cfg-debris-ttl" class="config-slider" min="1000" max="30000" step="500" value="10000" />
+            <span class="config-value"><span id="cfg-debris-ttl-value">10.0s</span></span>
+          </div>
+        </section>
+
+        <!-- Actions -->
+        <div class="control-actions">
+          <button id="btn-reset" class="button button-primary">&orarr; Reset Tower</button>
+          <button id="btn-debug" class="button">&#9671; Show Debug</button>
+        </div>
+
+        <!-- Status -->
+        <section class="status-panel">
+          <h2>Simulation</h2>
+          <div class="status-grid">
+            <div class="status-item"><span class="status-label">Bodies</span><span class="status-value" id="stat-bodies">0</span></div>
+            <div class="status-item"><span class="status-label">Bonds</span><span class="status-value" id="stat-bonds">0</span></div>
+            <div class="status-item"><span class="status-label">Fragments</span><span class="status-value" id="stat-fragments">0</span></div>
+            <div class="status-item"><span class="status-label">Projectiles</span><span class="status-value" id="stat-projectiles">0</span></div>
+            <div class="status-item"><span class="status-label">Chunks</span><span class="status-value" id="stat-chunks">0</span></div>
+          </div>
+        </section>
+
+        <!-- Performance -->
+        <section class="status-panel">
+          <h2>Performance</h2>
+          <div class="status-grid">
+            <div class="status-item"><span class="status-label">Physics</span><span class="status-value" id="stat-physics-ms">&mdash; ms</span></div>
+            <div class="status-item"><span class="status-label">Render</span><span class="status-value" id="stat-render-ms">&mdash; ms</span></div>
+            <div class="status-item"><span class="status-label">Draw Calls</span><span class="status-value" id="stat-draw-calls">0</span></div>
+            <div class="status-item"><span class="status-label">Triangles</span><span class="status-value" id="stat-triangles">0</span></div>
+          </div>
+        </section>
+      </aside>
+    </main>
+
+    <script>
+      (function () {
+        var toggle = document.getElementById('sidebar-toggle');
+        var sidebar = document.getElementById('sidebar');
+        var backdrop = document.getElementById('sidebar-backdrop');
+        var layout = document.querySelector('.layout');
+        var mql = window.matchMedia('(max-width: 768px)');
+        function isMobile() { return mql.matches; }
+        function close() { toggle.classList.remove('active'); if (isMobile()) { sidebar.classList.remove('open'); backdrop.classList.remove('visible'); } else { layout.classList.add('sidebar-hidden'); } }
+        function open() { toggle.classList.add('active'); if (isMobile()) { sidebar.classList.add('open'); backdrop.classList.add('visible'); } else { layout.classList.remove('sidebar-hidden'); } }
+        function isOpen() { return isMobile() ? sidebar.classList.contains('open') : !layout.classList.contains('sidebar-hidden'); }
+        toggle.addEventListener('click', function () { if (isOpen()) close(); else open(); });
+        backdrop.addEventListener('click', close);
+        if (!isMobile()) toggle.classList.add('active');
+      })();
+    </script>
+    <script type="module" src="./dist/fractured-tower.js"></script>
+  </body>
+</html>

--- a/blast/js_stress_example/fractured-tower.ts
+++ b/blast/js_stress_example/fractured-tower.ts
@@ -17,12 +17,8 @@ import { buildDestructibleCore } from 'blast-stress-solver/rapier';
 import {
   createDestructibleThreeBundle,
   RapierDebugRenderer,
-  setPinataModule,
 } from 'blast-stress-solver/three';
 import { buildFracturedTowerScenario } from 'blast-stress-solver/scenarios';
-
-// Register pinata module for browser ESM (required before fractureGeometry calls)
-setPinataModule(pinata as any);
 
 // ── Config ────────────────────────────────────────────────────
 
@@ -173,6 +169,7 @@ async function initScene() {
     fragmentCountPerFloor,
     fragmentCountPerColumn,
     deckMass,
+    pinata: pinata as any,
   });
 
   console.log(

--- a/blast/js_stress_example/fractured-tower.ts
+++ b/blast/js_stress_example/fractured-tower.ts
@@ -1,0 +1,370 @@
+/**
+ * Fractured Tower Demo
+ *
+ * Multi-floor tower with Voronoi-fractured walls, interior columns,
+ * floor plates, and a grid foundation. Uses three-pinata for irregular
+ * fragment generation and the blast-stress-solver runtime for
+ * stress-driven destruction.
+ *
+ * Click the viewport to launch projectiles at the tower.
+ */
+
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import Stats from 'three/addons/libs/stats.module.js';
+import * as pinata from '@dgreenheck/three-pinata';
+import { buildDestructibleCore } from 'blast-stress-solver/rapier';
+import {
+  createDestructibleThreeBundle,
+  RapierDebugRenderer,
+  setPinataModule,
+} from 'blast-stress-solver/three';
+import { buildFracturedTowerScenario } from 'blast-stress-solver/scenarios';
+
+// Register pinata module for browser ESM (required before fractureGeometry calls)
+setPinataModule(pinata as any);
+
+// ── Config ────────────────────────────────────────────────────
+
+const CONFIG = {
+  tower: {
+    width: 8,
+    floorCount: 4,
+    floorHeight: 3,
+    fragmentCountPerWall: 6,
+    fragmentCountPerFloor: 6,
+    fragmentCountPerColumn: 3,
+    deckMass: 20_000,
+  },
+  projectile: {
+    radius: 0.5,
+    mass: 20_000,
+    speed: 25,
+  },
+  solver: {
+    gravity: -9.81,
+    materialScale: 1e8,
+  },
+  physics: {
+    debrisCollisionMode: 'noDebrisPairs' as string,
+    friction: 0.25,
+    restitution: 0.0,
+    contactForceScale: 30,
+  },
+  optimization: {
+    smallBodyDampingMode: 'always' as string,
+    debrisCleanupMode: 'always' as string,
+    debrisTtlMs: 10000,
+    maxCollidersForDebris: 2,
+  },
+};
+
+// ── Three.js setup ────────────────────────────────────────────
+
+const canvas = document.getElementById('demo-canvas') as HTMLCanvasElement;
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+renderer.setSize(canvas.clientWidth, canvas.clientHeight, false);
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x0a0d13);
+scene.fog = new THREE.FogExp2(0x0a0d13, 0.012);
+
+const camera = new THREE.PerspectiveCamera(
+  55,
+  canvas.clientWidth / canvas.clientHeight,
+  0.1,
+  400,
+);
+camera.position.set(0, 10, 30);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 6, 0);
+controls.enableDamping = true;
+controls.dampingFactor = 0.08;
+controls.update();
+
+// Lights
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.4);
+scene.add(ambientLight);
+
+const dirLight = new THREE.DirectionalLight(0xffeedd, 1.0);
+dirLight.position.set(12, 20, 15);
+dirLight.castShadow = true;
+dirLight.shadow.mapSize.set(2048, 2048);
+dirLight.shadow.camera.left = -25;
+dirLight.shadow.camera.right = 25;
+dirLight.shadow.camera.top = 30;
+dirLight.shadow.camera.bottom = -5;
+scene.add(dirLight);
+
+// Ground plane
+const groundGeo = new THREE.PlaneGeometry(120, 120);
+const groundMat = new THREE.MeshStandardMaterial({
+  color: 0x1a1e2f,
+  roughness: 0.85,
+  metalness: 0.1,
+});
+const groundMesh = new THREE.Mesh(groundGeo, groundMat);
+groundMesh.rotation.x = -Math.PI / 2;
+groundMesh.position.y = -0.35;
+groundMesh.receiveShadow = true;
+scene.add(groundMesh);
+
+// ── Stats panel ──────────────────────────────────────────────
+
+const stats = new Stats();
+stats.dom.style.position = 'absolute';
+stats.dom.style.top = '0';
+stats.dom.style.left = '0';
+(document.querySelector('.viewport') as HTMLElement)?.appendChild(stats.dom);
+
+// ── Perf tracking ────────────────────────────────────────────
+
+let _physicsMs = 0;
+let _renderMs = 0;
+const EMA = 0.12;
+
+function updatePerfStats() {
+  const el = (id: string) => document.getElementById(id);
+  el('stat-physics-ms')!.textContent = _physicsMs.toFixed(1) + ' ms';
+  el('stat-render-ms')!.textContent = _renderMs.toFixed(1) + ' ms';
+  el('stat-draw-calls')!.textContent = String(renderer.info.render.calls);
+  el('stat-triangles')!.textContent = renderer.info.render.triangles.toLocaleString();
+}
+
+function updateStatus(core: any) {
+  const el = (id: string) => document.getElementById(id);
+  el('stat-bodies')!.textContent = String(core.getRigidBodyCount());
+  el('stat-bonds')!.textContent = String(core.getActiveBondsCount());
+  el('stat-projectiles')!.textContent = String(core.projectiles.length);
+  const active = core.chunks.filter((c: any) => c.active).length;
+  const detached = core.chunks.filter((c: any) => c.detached).length;
+  el('stat-chunks')!.textContent = `${active} / ${detached} detached`;
+  el('stat-fragments')!.textContent = String(core.chunks.length);
+}
+
+// ── Main ─────────────────────────────────────────────────────
+
+let coreRef: Awaited<ReturnType<typeof buildDestructibleCore>> | null = null;
+let visualsRef: ReturnType<typeof createDestructibleThreeBundle> | null = null;
+let rapierDebug: RapierDebugRenderer | null = null;
+let showDebug = false;
+
+async function initScene() {
+  const { width, floorCount, floorHeight, fragmentCountPerWall, fragmentCountPerFloor, fragmentCountPerColumn, deckMass } = CONFIG.tower;
+
+  const hint = document.querySelector('.viewport-hint') as HTMLElement;
+  if (hint) hint.textContent = 'Building tower...';
+
+  const scenario = await buildFracturedTowerScenario({
+    width,
+    depth: width,
+    floorCount,
+    floorHeight,
+    thickness: 0.3,
+    floorThickness: 0.2,
+    columnSize: 0.6,
+    columnsX: 2,
+    columnsZ: 2,
+    fragmentCountPerWall,
+    fragmentCountPerFloor,
+    fragmentCountPerColumn,
+    deckMass,
+  });
+
+  console.log(
+    `Fractured tower: ${scenario.nodes.length} nodes, ${scenario.bonds.length} bonds`,
+  );
+
+  const core = await buildDestructibleCore({
+    scenario,
+    gravity: CONFIG.solver.gravity,
+    materialScale: CONFIG.solver.materialScale,
+    friction: CONFIG.physics.friction,
+    restitution: CONFIG.physics.restitution,
+    contactForceScale: CONFIG.physics.contactForceScale,
+    debrisCollisionMode: CONFIG.physics.debrisCollisionMode as any,
+    damage: { enabled: false },
+    debrisCleanup: {
+      mode: CONFIG.optimization.debrisCleanupMode as any,
+      debrisTtlMs: CONFIG.optimization.debrisTtlMs,
+      maxCollidersForDebris: CONFIG.optimization.maxCollidersForDebris,
+    },
+    smallBodyDamping: {
+      mode: CONFIG.optimization.smallBodyDampingMode as any,
+      colliderCountThreshold: 3,
+      minLinearDamping: 2,
+      minAngularDamping: 2,
+    },
+  });
+
+  const group = new THREE.Group();
+  scene.add(group);
+
+  const visuals = createDestructibleThreeBundle({
+    core,
+    scenario,
+    root: group,
+    useBatchedMesh: true,
+    batchedMeshOptions: { enableBVH: false, bvhMargin: 5 },
+    includeDebugLines: true,
+  });
+
+  rapierDebug?.dispose();
+  rapierDebug = new RapierDebugRenderer(scene, core.world as any, { enabled: showDebug });
+
+  coreRef = core;
+  visualsRef = visuals;
+
+  if (hint) hint.textContent = 'Click to shoot projectiles';
+}
+
+// ── Projectile shooting ──────────────────────────────────────
+
+function shootProjectile(ndcX: number, ndcY: number) {
+  const core = coreRef;
+  if (!core) return;
+  const raycaster = new THREE.Raycaster();
+  raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
+  const dir = raycaster.ray.direction.clone().normalize();
+  core.enqueueProjectile({
+    position: { x: camera.position.x, y: camera.position.y, z: camera.position.z },
+    velocity: { x: dir.x * CONFIG.projectile.speed, y: dir.y * CONFIG.projectile.speed, z: dir.z * CONFIG.projectile.speed },
+    radius: CONFIG.projectile.radius,
+    mass: CONFIG.projectile.mass,
+    ttl: 8000,
+  });
+}
+
+canvas.addEventListener('click', (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const ndcX = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+  const ndcY = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+  shootProjectile(ndcX, ndcY);
+});
+
+// ── UI wiring ────────────────────────────────────────────────
+
+document.getElementById('btn-reset')?.addEventListener('click', async () => {
+  visualsRef?.dispose();
+  coreRef?.dispose();
+  coreRef = null;
+  visualsRef = null;
+  await initScene();
+});
+
+document.getElementById('btn-debug')?.addEventListener('click', () => {
+  showDebug = !showDebug;
+  rapierDebug?.setEnabled(showDebug);
+  const btn = document.getElementById('btn-debug')!;
+  btn.textContent = showDebug ? '\u25C8 Hide Debug' : '\u25C7 Show Debug';
+});
+
+function bindSlider(id: string, obj: Record<string, any>, key: string, fmt?: (v: number) => string) {
+  const slider = document.getElementById(id) as HTMLInputElement | null;
+  const display = document.getElementById(id + '-value');
+  if (!slider) return;
+  slider.value = String(obj[key]);
+  if (display) display.textContent = fmt ? fmt(obj[key]) : String(obj[key]);
+  slider.addEventListener('input', () => {
+    const v = parseFloat(slider.value);
+    obj[key] = v;
+    if (display) display.textContent = fmt ? fmt(v) : String(v);
+  });
+}
+
+function bindSelect(id: string, obj: Record<string, any>, key: string, onChange?: (v: string) => void) {
+  const select = document.getElementById(id) as HTMLSelectElement | null;
+  if (!select) return;
+  select.value = String(obj[key]);
+  select.addEventListener('change', () => { obj[key] = select.value; onChange?.(select.value); });
+}
+
+// Tower config (deferred)
+bindSlider('cfg-width', CONFIG.tower, 'width');
+bindSlider('cfg-floors', CONFIG.tower, 'floorCount');
+bindSlider('cfg-floor-height', CONFIG.tower, 'floorHeight');
+bindSlider('cfg-wall-frags', CONFIG.tower, 'fragmentCountPerWall');
+bindSlider('cfg-floor-frags', CONFIG.tower, 'fragmentCountPerFloor');
+bindSlider('cfg-total-mass', CONFIG.tower, 'deckMass', (v) => v.toLocaleString());
+
+// Projectile
+bindSlider('cfg-proj-radius', CONFIG.projectile, 'radius', (v) => v.toFixed(2));
+bindSlider('cfg-proj-mass', CONFIG.projectile, 'mass', (v) => v.toLocaleString());
+bindSlider('cfg-proj-speed', CONFIG.projectile, 'speed', (v) => v.toFixed(0));
+
+// Solver
+bindSlider('cfg-gravity', CONFIG.solver, 'gravity', (v) => v.toFixed(1));
+{
+  const slider = document.getElementById('cfg-material') as HTMLInputElement | null;
+  const display = document.getElementById('cfg-material-value');
+  if (slider) {
+    const exp = Math.log10(CONFIG.solver.materialScale);
+    slider.value = String(exp);
+    if (display) display.textContent = `1e${exp.toFixed(0)}`;
+    slider.addEventListener('input', () => {
+      const e = parseFloat(slider.value);
+      CONFIG.solver.materialScale = Math.pow(10, e);
+      if (display) display.textContent = `1e${e.toFixed(1)}`;
+    });
+  }
+}
+
+// Physics (live)
+bindSelect('cfg-debris-collision', CONFIG.physics, 'debrisCollisionMode', (v) => { coreRef?.setDebrisCollisionMode(v as any); });
+bindSlider('cfg-friction', CONFIG.physics, 'friction', (v) => v.toFixed(2));
+bindSlider('cfg-restitution', CONFIG.physics, 'restitution', (v) => v.toFixed(2));
+bindSlider('cfg-contact-force', CONFIG.physics, 'contactForceScale', (v) => v.toFixed(0));
+
+// Optimization (live)
+bindSelect('cfg-damping-mode', CONFIG.optimization, 'smallBodyDampingMode', (v) => { coreRef?.setSmallBodyDamping?.({ mode: v as any }); });
+bindSelect('cfg-cleanup-mode', CONFIG.optimization, 'debrisCleanupMode', (v) => { coreRef?.setDebrisCleanup?.({ mode: v as any, debrisTtlMs: CONFIG.optimization.debrisTtlMs }); });
+bindSlider('cfg-debris-ttl', CONFIG.optimization, 'debrisTtlMs', (v) => (v / 1000).toFixed(1) + 's');
+
+// ── Render loop ──────────────────────────────────────────────
+
+const clock = new THREE.Clock();
+
+function loop() {
+  requestAnimationFrame(loop);
+  stats.begin();
+  const dt = Math.min(clock.getDelta(), 1 / 30);
+  controls.update();
+
+  if (coreRef && visualsRef) {
+    const t0 = performance.now();
+    coreRef.step(dt);
+    _physicsMs += ((performance.now() - t0) - _physicsMs) * EMA;
+    visualsRef.update({ debug: showDebug, updateBVH: false, updateProjectiles: true });
+    rapierDebug?.update();
+    updateStatus(coreRef);
+  }
+
+  const t1 = performance.now();
+  renderer.render(scene, camera);
+  _renderMs += ((performance.now() - t1) - _renderMs) * EMA;
+  updatePerfStats();
+  stats.end();
+}
+
+// ── Resize ───────────────────────────────────────────────────
+
+function onResize() {
+  const w = canvas.clientWidth;
+  const h = canvas.clientHeight;
+  renderer.setSize(w, h, false);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener('resize', onResize);
+
+// ── Boot ─────────────────────────────────────────────────────
+
+initScene().then(() => loop()).catch((err) => {
+  console.error('Failed to initialize fractured tower demo:', err);
+  const hint = document.querySelector('.viewport-hint');
+  if (hint) hint.textContent = `Error: ${err.message}`;
+});

--- a/blast/js_stress_example/tsconfig.json
+++ b/blast/js_stress_example/tsconfig.json
@@ -28,6 +28,8 @@
     "wall-demolition.ts",
     "tower-collapse.ts",
     "fractured-wall.ts",
+    "fractured-tower.ts",
+    "fractured-bridge.ts",
     "fracture-policy.ts",
     "rapier-debug-renderer.js",
     "extBridgeScenario.js",


### PR DESCRIPTION
Port fracturedTowerScenario and fracturedBridgeScenario from vibe-city, rebuilt on top of blast-stress-solver's existing infrastructure for better performance (O(n log n) broadphase bond detection vs O(n²)), cleaner module separation, and proper pinata module management.

New files:
- three/fractureBuilders.ts: Reusable wall/floor/column fragment builders and grid foundation generator with bond strength multiplier system (column-column 4x, column-any 2.5x, floor-floor 2x, floor-wall 1.5x)
- scenarios/fracturedTowerScenario.ts: Multi-floor tower with exterior walls, interior column grid, floor plates, roof, and grid foundation
- scenarios/fracturedBridgeScenario.ts: Beam bridge with fractured deck, support posts, and footing supports
- tests/three.fractureBuilders.test.ts: 10 tests for builders + multipliers
- tests/scenarios.fractured.test.ts: 6 integration tests for both scenarios

Extended FragmentInfo type with optional fragmentType field for structural role tracking (column/floor/wall/foundation).

https://claude.ai/code/session_018YXszTQNeGTG346dVwcodZ

<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->
