### PR TITLE
fix(blast-stress-solver): build on wasm32-unknown-unknown without wasi-libc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,52 @@ jobs:
         working-directory: blast/js_stress_example
         run: npm run test:split || true  # organicSplit.spec.ts has a known stale expectation
 
+  wasm-smoke:
+    # Regression tests that build a cdylib consumer for
+    # wasm32-unknown-unknown and assert that the blast-stress-solver
+    # crate ships no stray libc imports (`env.*`) and no wasi imports
+    # (`wasi_snapshot_preview1.*`). Either class of import breaks
+    # downstream wasm-bindgen consumers — see the doc-comment at the
+    # top of blast/blast-stress-solver-rs/tests/wasm_smoke_test.rs.
+    name: WASM Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain + wasm target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasi C++ toolchain
+        # Provides the sysroot + libc++ the crate's build.rs probes
+        # for when the target is wasm32-unknown-unknown. See
+        # blast/blast-stress-solver-rs/build.rs for the probe paths.
+        run: sudo apt-get update && sudo apt-get install -y libc++-18-dev-wasm32 wasi-libc
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            blast/blast-stress-solver-rs/target
+            blast/blast-stress-solver-rs/tests/wasm_smoke/fixture/target
+          key: wasm-smoke-${{ runner.os }}-${{ hashFiles('blast/blast-stress-solver-rs/Cargo.toml', 'blast/blast-stress-solver-rs/tests/wasm_smoke/fixture/Cargo.toml') }}
+
+      - name: Run wasm-smoke regression tests
+        working-directory: blast/blast-stress-solver-rs
+        run: cargo test --features wasm-smoke --test wasm_smoke_test -- --nocapture
+
   deploy-preview:
     name: Deploy Preview
     needs: build

--- a/blast/blast-stress-solver-rs/.gitignore
+++ b/blast/blast-stress-solver-rs/.gitignore
@@ -1,1 +1,5 @@
 /target/
+# Nested target dir for the wasm-smoke fixture crate (which is an
+# isolated workspace root under tests/wasm_smoke/fixture/).
+/tests/wasm_smoke/fixture/target/
+/tests/wasm_smoke/fixture/Cargo.lock

--- a/blast/blast-stress-solver-rs/Cargo.lock
+++ b/blast/blast-stress-solver-rs/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "rapier3d",
  "serde",
  "serde_json",
+ "wasmparser",
 ]
 
 [[package]]
@@ -105,6 +106,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -285,14 +292,30 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heapless"
@@ -302,6 +325,18 @@ checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -464,8 +499,8 @@ dependencies = [
  "downcast-rs",
  "either",
  "ena",
- "foldhash",
- "hashbrown",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
  "log",
  "nalgebra",
  "num-derive",
@@ -587,6 +622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,7 +707,7 @@ version = "2.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "num-traits",
  "robust",
  "smallvec",
@@ -726,6 +767,19 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasmparser"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
 
 [[package]]
 name = "wide"

--- a/blast/blast-stress-solver-rs/Cargo.toml
+++ b/blast/blast-stress-solver-rs/Cargo.toml
@@ -10,6 +10,14 @@ links = "blast_stress_solver_ffi"
 default = []
 rapier = ["dep:rapier3d"]
 scenarios = []
+# Opt-in regression tests for the `wasm32-unknown-unknown` build. These
+# shell out to `cargo` to build a fixture cdylib under
+# `tests/wasm_smoke/fixture/`, then inspect the resulting .wasm for
+# stray `env.*` / `wasi_snapshot_preview1.*` imports. Enable with
+# `cargo test -p blast-stress-solver --features wasm-smoke`. Requires the
+# `wasm32-unknown-unknown` target and a wasi C++ toolchain
+# (e.g. `libc++-18-dev-wasm32`) to be installed on the host.
+wasm-smoke = []
 
 [dependencies]
 rapier3d = { version = "0.30", default-features = false, features = ["dim3", "f32"], optional = true }
@@ -21,3 +29,4 @@ cc = "1.0"
 rapier3d = { version = "0.30", default-features = false, features = ["dim3", "f32"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+wasmparser = "0.224"

--- a/blast/blast-stress-solver-rs/build.rs
+++ b/blast/blast-stress-solver-rs/build.rs
@@ -1,10 +1,16 @@
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
     let blast_root = manifest_dir.parent().expect("blast dir");
     let repo_root = blast_root.parent().expect("repo root");
+
+    let target = env::var("TARGET").unwrap_or_default();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let is_wasm = target_arch == "wasm32";
+    let is_wasm_unknown = is_wasm && target == "wasm32-unknown-unknown";
 
     let blast = repo_root.join("blast");
     let ffi_dir = blast.join("rust_stress_example/ffi");
@@ -54,6 +60,99 @@ fn main() {
     let mut build = cc::Build::new();
     build.cpp(true);
 
+    // --- WebAssembly (wasm32-unknown-unknown) support ---
+    //
+    // The upstream crate targets native + (aspirationally) wasm32. When
+    // cargo is invoked with `--target wasm32-unknown-unknown` we need to
+    // (a) compile the C++ against the wasi libc/libc++ that ships with
+    // clang-18+ (Ubuntu: `libc++-18-dev-wasm32` + `wasi-libc`), and
+    // (b) override the clang target so it picks up those headers —
+    // clang refuses to use the wasi sysroot when the triple is
+    // `wasm32-unknown-unknown`.
+    //
+    // Users can force specific paths via the `BLAST_WASM_SYSROOT` and
+    // `BLAST_WASM_CXX_INCLUDE` env vars; otherwise we probe a few
+    // common locations. This logic is no-op on native targets.
+    if is_wasm_unknown {
+        build.target("wasm32-wasi");
+
+        let sysroot = env::var("BLAST_WASM_SYSROOT")
+            .ok()
+            .or_else(|| probe_wasi_sysroot().map(|p| p.display().to_string()));
+        let cxx_include = env::var("BLAST_WASM_CXX_INCLUDE")
+            .ok()
+            .or_else(|| probe_libcxx_wasm_include().map(|p| p.display().to_string()));
+
+        if let Some(sysroot) = &sysroot {
+            println!("cargo:rerun-if-env-changed=BLAST_WASM_SYSROOT");
+            build.flag(&format!("--sysroot={sysroot}"));
+        }
+        if let Some(cxx_include) = &cxx_include {
+            println!("cargo:rerun-if-env-changed=BLAST_WASM_CXX_INCLUDE");
+            build.flag("-isystem");
+            build.flag(cxx_include);
+        }
+
+        if sysroot.is_none() || cxx_include.is_none() {
+            println!(
+                "cargo:warning=blast-stress-solver: wasi sysroot or libc++ headers not found — \
+                 set BLAST_WASM_SYSROOT and BLAST_WASM_CXX_INCLUDE, or install \
+                 `wasi-libc` + `libc++-18-dev-wasm32` (Debian/Ubuntu)."
+            );
+        }
+
+        // Tell rustc where to find `libc++.a` / `libc++abi.a` when the
+        // final link step resolves the `-lc++` the `cc` crate injects
+        // automatically for C++ source units. wasm32-unknown-unknown has
+        // no libc++ in the rust sysroot, so we point it at the libcxx
+        // shipped by `libc++-*-dev-wasm32`.
+        //
+        // BLAST_WASM_CXX_LIB_DIR lets users override for non-Debian
+        // layouts; otherwise we probe a few well-known locations.
+        let cxx_lib_dir = env::var("BLAST_WASM_CXX_LIB_DIR")
+            .ok()
+            .or_else(|| probe_libcxx_wasm_lib().map(|p| p.display().to_string()));
+        if let Some(dir) = &cxx_lib_dir {
+            println!("cargo:rerun-if-env-changed=BLAST_WASM_CXX_LIB_DIR");
+            println!("cargo:rustc-link-search=native={dir}");
+            // `cc` already passes `-lc++` on wasm32, but we also need
+            // `c++abi` (exception unwinding stubs) even with -fno-exceptions.
+            println!("cargo:rustc-link-lib=static=c++abi");
+        } else {
+            println!(
+                "cargo:warning=blast-stress-solver: wasm libc++.a not found — \
+                 set BLAST_WASM_CXX_LIB_DIR or install `libc++-18-dev-wasm32`."
+            );
+        }
+
+        // We do NOT link wasi-libc.  Doing so would pull
+        // `wasi_snapshot_preview1` imports into the final wasm, which
+        // in turn causes wasm-bindgen to wrap every export in a
+        // `command_export` shim that calls `__wasm_call_dtors →
+        // __funcs_on_exit → __stdio_exit`.  Those walk wasi-libc's
+        // atexit table, which is never initialised when we load the
+        // module as a library, and every `__wbindgen_malloc` call
+        // traps.
+        //
+        // Instead, we provide pure-Rust stubs for every libc symbol
+        // that the Blast C++ backend references, in
+        // `src/wasm_runtime_shims.rs`.  `malloc`/`free` forward to
+        // Rust's global allocator; stdio is no-op; string / memory
+        // helpers are pure Rust.  The final wasm has zero `env`
+        // imports and zero `wasi_snapshot_preview1` imports, so
+        // wasm-bindgen emits a normal library module.
+
+        // Suppress a cascade of warnings from the NV headers that assume a
+        // desktop-class compiler environment.
+        build.flag_if_supported("-Wno-unknown-pragmas");
+        build.flag_if_supported("-Wno-unused-parameter");
+        build.flag_if_supported("-Wno-unused-variable");
+        build.flag_if_supported("-Wno-deprecated-declarations");
+    }
+    // Silence noise about CARGO_CFG_* and target_os so incremental builds
+    // know to rerun when the triple changes.
+    let _ = &target_os;
+
     for src in bridge_sources.iter().chain(blast_sources.iter()) {
         build.file(src);
     }
@@ -84,3 +183,70 @@ fn main() {
 
     build.compile("blast_stress_solver_ffi");
 }
+
+/// Probe a few well-known locations for a wasi sysroot. Returns the first
+/// one that looks valid (contains `include/wasi/api.h`).
+fn probe_wasi_sysroot() -> Option<PathBuf> {
+    let candidates = [
+        "/usr/share/wasi-sysroot",
+        "/opt/wasi-sdk/share/wasi-sysroot",
+        "/usr",
+    ];
+    for c in candidates.iter() {
+        let p = PathBuf::from(c);
+        if p.join("include/wasm32-wasi/wasi/api.h").exists()
+            || p.join("include/wasi/api.h").exists()
+        {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Probe a few well-known locations for a directory containing
+/// `libc++.a` built for wasm32. Matches the layout shipped by
+/// Ubuntu's `libc++-*-dev-wasm32` package.
+fn probe_libcxx_wasm_lib() -> Option<PathBuf> {
+    let candidates = [
+        "/usr/lib/llvm-18/lib/wasm32-wasi",
+        "/usr/lib/llvm-19/lib/wasm32-wasi",
+        "/usr/lib/llvm-20/lib/wasm32-wasi",
+        "/usr/lib/llvm-17/lib/wasm32-wasi",
+        "/usr/lib/llvm-16/lib/wasm32-wasi",
+        "/usr/lib/wasm32-wasi",
+        "/opt/wasi-sdk/share/wasi-sysroot/lib/wasm32-wasi",
+    ];
+    for c in candidates.iter() {
+        let p = PathBuf::from(c);
+        if p.join("libc++.a").exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Probe a few well-known locations for a wasm-compatible libc++ header
+/// tree. Matches the layout shipped by Ubuntu's `libc++-*-dev-wasm32`.
+fn probe_libcxx_wasm_include() -> Option<PathBuf> {
+    let candidates = [
+        "/usr/lib/llvm-18/include/wasm32-wasi/c++/v1",
+        "/usr/lib/llvm-19/include/wasm32-wasi/c++/v1",
+        "/usr/lib/llvm-20/include/wasm32-wasi/c++/v1",
+        "/usr/lib/llvm-17/include/wasm32-wasi/c++/v1",
+        "/usr/lib/llvm-16/include/wasm32-wasi/c++/v1",
+        "/usr/include/wasm32-wasi/c++/v1",
+        "/opt/wasi-sdk/share/wasi-sysroot/include/c++/v1",
+    ];
+    for c in candidates.iter() {
+        let p = PathBuf::from(c);
+        if p.join("new").exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+// Silence dead_code on native builds where `Path` is unused by the wasm
+// probe helpers.
+#[allow(dead_code)]
+fn _assert_path_in_scope(_: &Path) {}

--- a/blast/blast-stress-solver-rs/src/lib.rs
+++ b/blast/blast-stress-solver-rs/src/lib.rs
@@ -39,8 +39,21 @@
 
 mod ffi;
 
+// On `wasm32-unknown-unknown` the Blast C++ backend references dozens
+// of libc symbols (malloc, fwrite, abort, …) through libc++'s STL
+// helpers.  We provide pure-Rust stubs for all of them in
+// `wasm_runtime_shims`, so the final wasm module imports neither
+// `env.*` libc functions nor `wasi_snapshot_preview1.*` wasi calls
+// — it is a pure library module.
 #[cfg(target_arch = "wasm32")]
 mod wasm_runtime_shims;
+
+// `-fno-exceptions` is not enough to strip every mention of
+// `__cxa_allocate_exception` / `__cxa_throw` from libc++ — STL
+// containers still emit them behind `throw_bad_alloc`-style helpers.
+// Provide trapping stubs so the wasm module stays self-contained.
+#[cfg(target_arch = "wasm32")]
+mod wasm_cxa_stubs;
 
 pub mod bond_stress;
 pub mod ext_stress_solver;

--- a/blast/blast-stress-solver-rs/src/wasm_cxa_stubs.rs
+++ b/blast/blast-stress-solver-rs/src/wasm_cxa_stubs.rs
@@ -1,0 +1,38 @@
+//! Trap-only stubs for the tiny surface of the Itanium C++ ABI that
+//! libc++ still references even when compiled with `-fno-exceptions`.
+//!
+//! Any call to these functions indicates the C++ backend hit an
+//! unexpected error path (e.g. out-of-memory inside `std::vector`).
+//! We trap immediately so the browser surfaces a WebAssembly
+//! RuntimeError with a clear stack frame rather than returning
+//! nonsense to the caller.
+
+/// libc++ calls `__cxa_allocate_exception` before constructing the
+/// exception object.  With `-fno-exceptions` the call is only emitted
+/// for unwind-friendly STL helpers; none of them are on the steady-
+/// state hot path, so aborting is fine.
+#[unsafe(no_mangle)]
+pub extern "C" fn __cxa_allocate_exception(_size: usize) -> *mut u8 {
+    core::arch::wasm32::unreachable()
+}
+
+/// Paired with `__cxa_allocate_exception`; libc++ calls this after
+/// filling in the exception object to start unwinding.  We never reach
+/// here in practice because `__cxa_allocate_exception` traps first,
+/// but linkers still want the symbol resolved.
+#[unsafe(no_mangle)]
+pub extern "C" fn __cxa_throw(
+    _thrown_object: *mut u8,
+    _tinfo: *mut u8,
+    _dest: *mut u8,
+) -> ! {
+    core::arch::wasm32::unreachable()
+}
+
+// `__funcs_on_exit` / `__stdio_exit` do not appear in the final wasm
+// at all: because we never link wasi-libc and our
+// `wasm_runtime_shims` module covers every libc reference, the
+// cdylib has zero `wasi_snapshot_preview1` imports, so wasm-bindgen
+// emits a normal library module rather than one wrapped in
+// `command_export` shims.  Nothing ever calls the exit hooks, so we
+// don't need to shadow them.

--- a/blast/blast-stress-solver-rs/src/wasm_runtime_shims.rs
+++ b/blast/blast-stress-solver-rs/src/wasm_runtime_shims.rs
@@ -1,60 +1,538 @@
-#[unsafe(no_mangle)]
-pub extern "C" fn __wasi_proc_exit(_code: u32) -> ! {
-    std::process::abort()
+//! Pure-Rust stubs for every libc symbol the Blast C++ backend (plus
+//! its transitive libc++ dependency) references on
+//! `wasm32-unknown-unknown`.
+//!
+//! ## Why
+//!
+//! `wasm32-unknown-unknown` ships no libc.  If we linked wasi-libc to
+//! resolve C++ calls like `malloc` / `fwrite` / `abort`, the final
+//! wasm would import from `wasi_snapshot_preview1` — and that in turn
+//! causes wasm-bindgen to wrap every export in a `command_export`
+//! shim that calls `__wasm_call_dtors → __funcs_on_exit →
+//! __stdio_exit`.  Those walk wasi-libc's atexit table, which is
+//! never initialised in library mode, so every
+//! `__wbindgen_malloc` / `__wbindgen_free` call traps.
+//!
+//! Instead we provide our own `#[no_mangle] extern "C"` stubs here.
+//! `malloc` / `free` / `realloc` forward to Rust's global allocator
+//! (via a 16-byte size header).  Stdio, locale, wide-char, and
+//! `strto*` routines are no-op stubs — the stress solver doesn't
+//! actually use them at runtime, but libc++'s STL error paths still
+//! reference them for fallback output.  Character-class helpers
+//! implement the ASCII subset directly.
+//!
+//! The result: the final cdylib has **zero** `env.*` libc imports and
+//! **zero** `wasi_snapshot_preview1.*` imports.  wasm-bindgen emits a
+//! normal library module with no command_export wrappers.
+
+use core::ffi::{c_char, c_int, c_void};
+use std::alloc::{alloc, dealloc, realloc as rust_realloc, Layout};
+
+// -----------------------------------------------------------------------------
+// Allocator
+// -----------------------------------------------------------------------------
+//
+// libc-style `malloc`/`free` don't carry a size parameter on `free`,
+// but Rust's `GlobalAlloc` requires one.  We prepend a 16-byte header
+// storing the user-requested size so `free`/`realloc` can reconstruct
+// the original `Layout`.  16 bytes also keeps the returned pointer
+// 16-aligned, which is stricter than what libc promises and matches
+// what libc++ assumes for SSE vector types.
+
+const HEADER_SIZE: usize = 16;
+const ALIGN: usize = 16;
+
+#[inline]
+fn layout_for(user_size: usize) -> Layout {
+    // +HEADER_SIZE so the pointer the user sees still has `user_size`
+    // bytes available after the header.
+    Layout::from_size_align(user_size + HEADER_SIZE, ALIGN).expect("layout")
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __wasi_fd_close(_fd: u32) -> u16 {
+pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
+    if size == 0 {
+        return core::ptr::null_mut();
+    }
+    let base = alloc(layout_for(size));
+    if base.is_null() {
+        return core::ptr::null_mut();
+    }
+    (base as *mut usize).write(size);
+    base.add(HEADER_SIZE) as *mut c_void
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn free(ptr: *mut c_void) {
+    if ptr.is_null() {
+        return;
+    }
+    let base = (ptr as *mut u8).sub(HEADER_SIZE);
+    let size = (base as *mut usize).read();
+    dealloc(base, layout_for(size));
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_void {
+    if ptr.is_null() {
+        return malloc(new_size);
+    }
+    if new_size == 0 {
+        free(ptr);
+        return core::ptr::null_mut();
+    }
+    let base = (ptr as *mut u8).sub(HEADER_SIZE);
+    let old_size = (base as *mut usize).read();
+    let new_base = rust_realloc(base, layout_for(old_size), new_size + HEADER_SIZE);
+    if new_base.is_null() {
+        return core::ptr::null_mut();
+    }
+    (new_base as *mut usize).write(new_size);
+    new_base.add(HEADER_SIZE) as *mut c_void
+}
+
+// -----------------------------------------------------------------------------
+// Fatal exit
+// -----------------------------------------------------------------------------
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn abort() -> ! {
+    // Emit a wasm `unreachable`, which traps the module.  Unlike
+    // `std::process::abort`, this does not call any exit handlers.
+    core::arch::wasm32::unreachable()
+}
+
+// -----------------------------------------------------------------------------
+// C++ static dtors
+// -----------------------------------------------------------------------------
+
+// libc++ registers every `thread_local` and function-local `static`
+// destructor via `__cxa_atexit`.  In library mode we never run them,
+// so just report success and drop the registration on the floor.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __cxa_atexit(
+    _func: *mut c_void,
+    _arg: *mut c_void,
+    _dso_handle: *mut c_void,
+) -> c_int {
+    0
+}
+
+// -----------------------------------------------------------------------------
+// String / memory helpers
+// -----------------------------------------------------------------------------
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn strcmp(a: *const c_char, b: *const c_char) -> c_int {
+    let mut i = 0isize;
+    loop {
+        let ca = *a.offset(i) as u8;
+        let cb = *b.offset(i) as u8;
+        if ca != cb {
+            return ca as c_int - cb as c_int;
+        }
+        if ca == 0 {
+            return 0;
+        }
+        i += 1;
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn memchr(s: *const c_void, c: c_int, n: usize) -> *mut c_void {
+    let p = s as *const u8;
+    let target = c as u8;
+    let mut i = 0usize;
+    while i < n {
+        if *p.add(i) == target {
+            return p.add(i) as *mut c_void;
+        }
+        i += 1;
+    }
+    core::ptr::null_mut()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn strerror(_errnum: c_int) -> *const c_char {
+    // Return a static empty C string.
+    static EMPTY: [u8; 1] = [0];
+    EMPTY.as_ptr() as *const c_char
+}
+
+// wchar_t on wasm32 is 32-bit.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wcslen(s: *const u32) -> usize {
+    let mut i = 0usize;
+    while *s.add(i) != 0 {
+        i += 1;
+    }
+    i
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wmemchr(s: *const u32, c: u32, n: usize) -> *mut u32 {
+    let mut i = 0usize;
+    while i < n {
+        if *s.add(i) == c {
+            return s.add(i) as *mut u32;
+        }
+        i += 1;
+    }
+    core::ptr::null_mut()
+}
+
+// -----------------------------------------------------------------------------
+// Stdio (no-op)
+// -----------------------------------------------------------------------------
+//
+// The stress solver only uses stdio for error / profiling output,
+// which we don't need.  Each stub succeeds silently.
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwrite(
+    _ptr: *const c_void,
+    _size: usize,
+    n: usize,
+    _stream: *mut c_void,
+) -> usize {
+    // Pretend the whole block was written.
+    n
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fflush(_stream: *mut c_void) -> c_int {
     0
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __wasi_fd_write(
-    _fd: u32,
-    _iovs: *const core::ffi::c_void,
-    _iovs_len: usize,
-    nwritten: *mut usize,
-) -> u16 {
-    if !nwritten.is_null() {
-        // The packaged wasm backend does not rely on stdio output.
-        unsafe { *nwritten = 0 };
+pub unsafe extern "C" fn fprintf(
+    _stream: *mut c_void,
+    _fmt: *const c_char,
+    _arg: *mut c_void,
+) -> c_int {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vfprintf(
+    _stream: *mut c_void,
+    _fmt: *const c_char,
+    _ap: *mut c_void,
+) -> c_int {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn snprintf(
+    buf: *mut c_char,
+    n: usize,
+    _fmt: *const c_char,
+    _arg: *mut c_void,
+) -> c_int {
+    if !buf.is_null() && n > 0 {
+        *buf = 0;
     }
     0
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __wasi_fd_read(
-    _fd: u32,
-    _iovs: *const core::ffi::c_void,
-    _iovs_len: usize,
-    nread: *mut usize,
-) -> u16 {
-    if !nread.is_null() {
-        unsafe { *nread = 0 };
+pub unsafe extern "C" fn vsnprintf(
+    buf: *mut c_char,
+    n: usize,
+    _fmt: *const c_char,
+    _ap: *mut c_void,
+) -> c_int {
+    if !buf.is_null() && n > 0 {
+        *buf = 0;
     }
     0
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __wasi_environ_sizes_get(count: *mut usize, bytes: *mut usize) -> u16 {
-    if !count.is_null() {
-        unsafe { *count = 0 };
-    }
-    if !bytes.is_null() {
-        unsafe { *bytes = 0 };
+pub unsafe extern "C" fn sscanf(
+    _s: *const c_char,
+    _fmt: *const c_char,
+    _arg: *mut c_void,
+) -> c_int {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vsscanf(
+    _s: *const c_char,
+    _fmt: *const c_char,
+    _ap: *mut c_void,
+) -> c_int {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vasprintf(
+    _strp: *mut *mut c_char,
+    _fmt: *const c_char,
+    _ap: *mut c_void,
+) -> c_int {
+    -1
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn getc(_stream: *mut c_void) -> c_int {
+    -1
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ungetc(_c: c_int, _stream: *mut c_void) -> c_int {
+    -1
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn getwc(_stream: *mut c_void) -> c_int {
+    -1
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ungetwc(_c: c_int, _stream: *mut c_void) -> c_int {
+    -1
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fputwc(_c: c_int, _stream: *mut c_void) -> c_int {
+    -1
+}
+
+// -----------------------------------------------------------------------------
+// Numeric parsing (strto*)
+// -----------------------------------------------------------------------------
+//
+// The Blast backend never invokes these at runtime — they're reachable
+// only through libc++'s locale / iostream fallback paths.  Returning
+// zero is safe: any code path that actually depended on the parsed
+// value would have to go through `operator<<` first, which is
+// similarly stubbed.
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn strtoll(
+    _nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    _base: c_int,
+) -> i64 {
+    if !endptr.is_null() {
+        *endptr = core::ptr::null_mut();
     }
     0
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __wasi_environ_get(_environ: *mut *mut u8, _environ_buf: *mut u8) -> u16 {
+pub unsafe extern "C" fn strtoull(
+    _nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    _base: c_int,
+) -> u64 {
+    if !endptr.is_null() {
+        *endptr = core::ptr::null_mut();
+    }
     0
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __wasi_fd_seek(_fd: u32, _offset: i64, _whence: u8, new_offset: *mut u64) -> u16 {
-    if !new_offset.is_null() {
-        unsafe { *new_offset = 0 };
+pub unsafe extern "C" fn strtof_l(
+    _nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    _loc: *mut c_void,
+) -> f32 {
+    if !endptr.is_null() {
+        *endptr = core::ptr::null_mut();
+    }
+    0.0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn strtod_l(
+    _nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    _loc: *mut c_void,
+) -> f64 {
+    if !endptr.is_null() {
+        *endptr = core::ptr::null_mut();
+    }
+    0.0
+}
+
+/// `long double strtold_l(...)` returns via an sret pointer on wasm32
+/// because `long double` is larger than a scalar result can carry.
+/// The caller has already reserved 16 bytes of stack; zero them out.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn strtold_l(
+    result: *mut u8,
+    _nptr: *const c_char,
+    endptr: *mut *mut c_char,
+    _loc: *mut c_void,
+) {
+    if !result.is_null() {
+        core::ptr::write_bytes(result, 0, 16);
+    }
+    if !endptr.is_null() {
+        *endptr = core::ptr::null_mut();
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Locale (no-op)
+// -----------------------------------------------------------------------------
+//
+// libc++ creates one `locale_t` for the "C" locale at startup.  Any
+// non-null pointer works as a sentinel — we never dereference it.
+
+const FAKE_LOCALE: *mut c_void = 1 as *mut c_void;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn newlocale(
+    _category_mask: c_int,
+    _locale: *const c_char,
+    _base: *mut c_void,
+) -> *mut c_void {
+    FAKE_LOCALE
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn uselocale(_loc: *mut c_void) -> *mut c_void {
+    FAKE_LOCALE
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn freelocale(_loc: *mut c_void) {}
+
+// -----------------------------------------------------------------------------
+// Character classes
+// -----------------------------------------------------------------------------
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn toupper(c: c_int) -> c_int {
+    if (b'a' as c_int..=b'z' as c_int).contains(&c) {
+        c - 32
+    } else {
+        c
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tolower(c: c_int) -> c_int {
+    if (b'A' as c_int..=b'Z' as c_int).contains(&c) {
+        c + 32
+    } else {
+        c
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn isdigit_l(c: c_int, _loc: *mut c_void) -> c_int {
+    (b'0' as c_int..=b'9' as c_int).contains(&c) as c_int
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn isxdigit_l(c: c_int, _loc: *mut c_void) -> c_int {
+    let ok = (b'0' as c_int..=b'9' as c_int).contains(&c)
+        || (b'a' as c_int..=b'f' as c_int).contains(&c)
+        || (b'A' as c_int..=b'F' as c_int).contains(&c);
+    ok as c_int
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn islower_l(c: c_int, _loc: *mut c_void) -> c_int {
+    (b'a' as c_int..=b'z' as c_int).contains(&c) as c_int
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn isupper_l(c: c_int, _loc: *mut c_void) -> c_int {
+    (b'A' as c_int..=b'Z' as c_int).contains(&c) as c_int
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iswlower_l(c: c_int, _loc: *mut c_void) -> c_int {
+    (b'a' as c_int..=b'z' as c_int).contains(&c) as c_int
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __ctype_get_mb_cur_max() -> usize {
+    // ASCII / UTF-8: one byte per character in the "C" locale.
+    1
+}
+
+// -----------------------------------------------------------------------------
+// Multibyte / wide-char (no-op)
+// -----------------------------------------------------------------------------
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mbsrtowcs(
+    _dst: *mut u32,
+    _src: *mut *const c_char,
+    _len: usize,
+    _ps: *mut c_void,
+) -> usize {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mbsnrtowcs(
+    _dst: *mut u32,
+    _src: *mut *const c_char,
+    _nms: usize,
+    _len: usize,
+    _ps: *mut c_void,
+) -> usize {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wcsnrtombs(
+    _dst: *mut c_char,
+    _src: *mut *const u32,
+    _nwc: usize,
+    _len: usize,
+    _ps: *mut c_void,
+) -> usize {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wcrtomb(_s: *mut c_char, _wc: u32, _ps: *mut c_void) -> usize {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mbrtowc(
+    _pwc: *mut u32,
+    _s: *const c_char,
+    _n: usize,
+    _ps: *mut c_void,
+) -> usize {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mbtowc(_pwc: *mut u32, _s: *const c_char, _n: usize) -> c_int {
+    0
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mbrlen(_s: *const c_char, _n: usize, _ps: *mut c_void) -> usize {
+    0
+}
+
+// -----------------------------------------------------------------------------
+// Time formatting (no-op)
+// -----------------------------------------------------------------------------
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn strftime_l(
+    buf: *mut c_char,
+    n: usize,
+    _fmt: *const c_char,
+    _tm: *mut c_void,
+    _loc: *mut c_void,
+) -> usize {
+    if !buf.is_null() && n > 0 {
+        *buf = 0;
     }
     0
 }

--- a/blast/blast-stress-solver-rs/src/wasm_runtime_shims.rs
+++ b/blast/blast-stress-solver-rs/src/wasm_runtime_shims.rs
@@ -91,6 +91,24 @@ pub unsafe extern "C" fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_vo
     new_base.add(HEADER_SIZE) as *mut c_void
 }
 
+/// POSIX `aligned_alloc(alignment, size)`.  libc++'s
+/// `__libcpp_aligned_alloc` routes here from `operator new(size,
+/// align_val_t)`.  Our `malloc` already returns 16-byte-aligned
+/// pointers (via the header trick), which covers every alignment
+/// the Blast backend actually requests on wasm — `NvcVec3`,
+/// `NvAlignedAllocator`, and every `std::vector` allocation — as
+/// long as the build passes `STRESS_SOLVER_FORCE_SCALAR` (no SSE
+/// vector types).  A stricter request would land on the `unreachable`
+/// branch and show up as a `wasm_fixture_instantiates_and_runs`
+/// failure, which is the signal to extend this shim.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn aligned_alloc(alignment: usize, size: usize) -> *mut c_void {
+    if alignment > ALIGN {
+        core::arch::wasm32::unreachable();
+    }
+    malloc(size)
+}
+
 // -----------------------------------------------------------------------------
 // Fatal exit
 // -----------------------------------------------------------------------------
@@ -197,6 +215,16 @@ pub unsafe extern "C" fn fwrite(
 ) -> usize {
     // Pretend the whole block was written.
     n
+}
+
+/// libc++'s `std::__put_character_sequence` (and by extension
+/// `operator<<(basic_ostream&, const char*)`) reaches for `fputc`
+/// on its slow path when the stream's `sputn` isn't available.
+/// We're not interested in the output — just pretend we wrote
+/// the character.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fputc(c: c_int, _stream: *mut c_void) -> c_int {
+    c
 }
 
 #[unsafe(no_mangle)]

--- a/blast/blast-stress-solver-rs/tests/wasm_smoke/fixture/Cargo.toml
+++ b/blast/blast-stress-solver-rs/tests/wasm_smoke/fixture/Cargo.toml
@@ -1,0 +1,43 @@
+# Minimal downstream-shaped consumer used by `tests/wasm_smoke_test.rs`
+# to exercise the `wasm32-unknown-unknown` build end-to-end.
+#
+# This crate is deliberately **not** part of any Cargo workspace — the
+# empty `[workspace]` table below makes it its own workspace root so
+# the parent crate's `cargo build` / `cargo test` never touches it.
+# The `wasm_smoke_test.rs` integration test shells out to `cargo build
+# --manifest-path` to build this fixture on demand.
+#
+# Why a separate crate? A downstream cdylib consumer is the only shape
+# that actually catches unresolved C++ imports: `cargo build` of an
+# rlib (what `cargo build -p blast-stress-solver --target
+# wasm32-unknown-unknown` produces) never links, so it silently hides
+# missing libc symbols. We have to produce a real cdylib and inspect
+# its import section.
+[package]
+name = "blast-wasm-smoke-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+license = "BSD-3-Clause"
+
+# Empty workspace table = this crate is its own workspace root, so it
+# doesn't inherit from (or get picked up by) any parent.
+[workspace]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+blast-stress-solver = { path = "../../..", default-features = false }
+# `wasm-bindgen` is only used on the wasm target — on native builds
+# the fixture compiles as a plain cdylib with no exported symbols,
+# which is fine (the fixture is never consumed natively).
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+
+# Size optimizations — the test only cares about the import section,
+# not runtime performance, and a smaller artifact parses faster.
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1

--- a/blast/blast-stress-solver-rs/tests/wasm_smoke/fixture/src/lib.rs
+++ b/blast/blast-stress-solver-rs/tests/wasm_smoke/fixture/src/lib.rs
@@ -1,0 +1,79 @@
+//! Fixture consumer used by `tests/wasm_smoke_test.rs`.
+//!
+//! The goal is to exercise the full C++ code path that libc / libc++
+//! can drag in on `wasm32-unknown-unknown`:
+//!
+//! - `ExtStressSolver::new` → `std::vector` allocations inside the
+//!   C++ backend (malloc / free / realloc path).
+//! - `add_gravity` + `update` → the core conjugate-gradient solver,
+//!   which transitively touches every compiled C++ TU.
+//! - `overstressed_bond_count` / `node_count` → FFI read-backs.
+//!
+//! If any of those paths references a libc symbol that isn't covered
+//! by `src/wasm_runtime_shims.rs`, the linker resolves it against
+//! `env.*` and the resulting wasm imports it — which is exactly what
+//! `tests/wasm_smoke_test.rs::wasm_fixture_has_no_libc_imports`
+//! forbids.
+//!
+//! We use `#[wasm_bindgen]` for the entry point (rather than a raw
+//! `extern "C"` export) because Bug B — the `command_export` runtime
+//! trap — only manifests when wasm-bindgen has at least one export
+//! to wrap. Running the `wasm_fixture_instantiates_and_runs` test
+//! against a bindgen-annotated export is what lets us catch any
+//! future wasm-bindgen change that re-introduces the trap.
+//!
+//! On native targets this crate still compiles (as a cdylib with no
+//! exported symbols) so that downstream workflows which recursively
+//! invoke `cargo build` over every manifest don't choke on it.
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+use blast_stress_solver::{BondDesc, ExtStressSolver, NodeDesc, SolverSettings, Vec3};
+
+/// Build a trivial 2-node / 1-bond scenario, run one solver tick
+/// under gravity, and return the overstressed bond count plus the
+/// node count.
+///
+/// Returning a numeric summary (rather than just calling into the
+/// solver for its side effects) prevents the optimizer from dead-
+/// code-eliminating the entire call graph.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub fn blast_wasm_smoke() -> u32 {
+    let nodes = [
+        // Fixed support at the origin.
+        NodeDesc {
+            centroid: Vec3::new(0.0, 0.0, 0.0),
+            mass: 0.0,
+            volume: 1.0,
+        },
+        // Dynamic mass 1 m above.
+        NodeDesc {
+            centroid: Vec3::new(0.0, 1.0, 0.0),
+            mass: 10.0,
+            volume: 1.0,
+        },
+    ];
+    let bonds = [BondDesc {
+        centroid: Vec3::new(0.0, 0.5, 0.0),
+        normal: Vec3::new(0.0, 1.0, 0.0),
+        area: 1.0,
+        node0: 0,
+        node1: 1,
+    }];
+    let settings = SolverSettings::default();
+
+    let Some(mut solver) = ExtStressSolver::new(&nodes, &bonds, &settings) else {
+        return u32::MAX;
+    };
+
+    // Apply gravity + one solver tick. This is the hot path that
+    // reaches into every compiled C++ translation unit.
+    solver.add_gravity(Vec3::new(0.0, -9.81, 0.0));
+    solver.update();
+
+    // Combine two read-backs so nothing in the call graph is dead.
+    solver
+        .overstressed_bond_count()
+        .wrapping_add(solver.node_count())
+}

--- a/blast/blast-stress-solver-rs/tests/wasm_smoke_test.rs
+++ b/blast/blast-stress-solver-rs/tests/wasm_smoke_test.rs
@@ -1,0 +1,298 @@
+//! Regression tests for the `wasm32-unknown-unknown` build.
+//!
+//! **Why these exist**: downstream consumers of this crate repeatedly
+//! hit two stacked WebAssembly build bugs that the main test suite
+//! silently missed:
+//!
+//! 1. **Bug A — unresolved `env.*` imports.** The C++ backend drags
+//!    in dozens of libc symbols via libc++. When downstream builds a
+//!    cdylib for `wasm32-unknown-unknown`, those symbols have to be
+//!    resolved somewhere. Historically the fix was to link
+//!    `wasi-libc`, which resolves them but see Bug B.
+//!
+//! 2. **Bug B — `command_export` runtime trap.** Linking wasi-libc
+//!    pulls in `wasi_snapshot_preview1` imports, which causes
+//!    `wasm-bindgen` to treat the module as a *command* (like a main
+//!    executable) rather than a *library*. It then wraps every export
+//!    in a shim that calls `__wasm_call_dtors → __funcs_on_exit →
+//!    __stdio_exit`, walking an uninitialised atexit table — so every
+//!    call into the module traps at runtime.
+//!
+//! The upstream fix is to provide pure-Rust stubs for every libc
+//! symbol the C++ backend references (see `src/wasm_runtime_shims.rs`)
+//! and **not** link wasi-libc. The final cdylib then has zero `env.*`
+//! imports and zero `wasi_snapshot_preview1.*` imports, and
+//! wasm-bindgen emits a normal library module.
+//!
+//! **What these tests do**: Test 1 (`wasm_fixture_has_no_libc_imports`)
+//! builds a minimal fixture cdylib under `tests/wasm_smoke/fixture/`,
+//! then parses the resulting `.wasm` file and asserts that no import
+//! comes from `env` or `wasi_snapshot_preview1`. Test 2
+//! (`wasm_fixture_instantiates_and_runs`) additionally runs the fixture
+//! through `wasm-pack` + Node to catch any future `command_export`
+//! trap. Test 2 is skipped (with a diagnostic message) if wasm-pack
+//! or node isn't available; Test 1 requires only `cargo` with the
+//! `wasm32-unknown-unknown` target installed plus a wasi C++ toolchain
+//! (`libc++-*-dev-wasm32` on Debian/Ubuntu).
+//!
+//! **Running them**:
+//!
+//! ```text
+//! rustup target add wasm32-unknown-unknown
+//! sudo apt-get install -y libc++-18-dev-wasm32   # or equivalent
+//! cargo test -p blast-stress-solver \
+//!     --features wasm-smoke --test wasm_smoke_test
+//! ```
+
+#![cfg(feature = "wasm-smoke")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Imports from `env` that we consider acceptable. **Zero tolerance
+/// by default** — every libc symbol should be stubbed in
+/// `src/wasm_runtime_shims.rs`. If a genuine wasm-bindgen glue import
+/// ever shows up here it belongs on this list, not in the shims.
+const ALLOWED_ENV_IMPORTS: &[&str] = &[];
+
+/// Imports from `wasi_snapshot_preview1` that we consider acceptable.
+/// **Zero tolerance, no exceptions.** A single wasi import flips
+/// wasm-bindgen into command-export mode and causes Bug B.
+const ALLOWED_WASI_IMPORTS: &[&str] = &[];
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture_dir() -> PathBuf {
+    manifest_dir().join("tests/wasm_smoke/fixture")
+}
+
+fn cargo_bin() -> String {
+    std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string())
+}
+
+/// Ensure the `wasm32-unknown-unknown` target is installed. If it
+/// isn't, `cargo build` below would fail with a cryptic "can't find
+/// crate for `core`" error; this check surfaces a clearer message.
+fn require_wasm_target() {
+    let out = Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .output();
+    if let Ok(out) = out {
+        let installed = String::from_utf8_lossy(&out.stdout);
+        if !installed.lines().any(|t| t.trim() == "wasm32-unknown-unknown") {
+            panic!(
+                "the `wasm32-unknown-unknown` target is not installed. \
+                 Run `rustup target add wasm32-unknown-unknown` and retry."
+            );
+        }
+    }
+    // If `rustup` isn't on PATH we can't check — fall through and
+    // let `cargo build` produce its own error.
+}
+
+/// Build the fixture cdylib for `wasm32-unknown-unknown` and return
+/// the path to the produced `.wasm`.
+///
+/// We deliberately use an isolated `CARGO_TARGET_DIR` so the fixture
+/// build doesn't contend with the outer test run's target dir and
+/// nested cargo invocations never see each other's lockfiles.
+fn build_fixture(release: bool) -> PathBuf {
+    require_wasm_target();
+
+    let fixture = fixture_dir();
+    let manifest_path = fixture.join("Cargo.toml");
+    let target_dir = fixture.join("target");
+
+    let mut cmd = Command::new(cargo_bin());
+    cmd.args([
+        "build",
+        "--target",
+        "wasm32-unknown-unknown",
+        "--manifest-path",
+    ])
+    .arg(&manifest_path)
+    .env("CARGO_TARGET_DIR", &target_dir);
+    if release {
+        cmd.arg("--release");
+    }
+
+    // Strip any `RUSTFLAGS` the outer test run might have set — they
+    // can inject native-target flags that break the wasm build.
+    cmd.env_remove("RUSTFLAGS");
+    cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
+
+    let status = cmd
+        .status()
+        .expect("failed to spawn cargo to build the wasm smoke fixture");
+    assert!(
+        status.success(),
+        "failed to build the wasm smoke fixture cdylib — see cargo output above"
+    );
+
+    let profile = if release { "release" } else { "debug" };
+    let wasm = target_dir
+        .join("wasm32-unknown-unknown")
+        .join(profile)
+        .join("blast_wasm_smoke_fixture.wasm");
+    assert!(
+        wasm.exists(),
+        "fixture built but produced no .wasm at {}",
+        wasm.display()
+    );
+    wasm
+}
+
+/// Collect every `(module, field)` import in the given wasm module.
+fn collect_imports(wasm_bytes: &[u8]) -> Vec<(String, String)> {
+    let mut imports = Vec::new();
+    for payload in wasmparser::Parser::new(0).parse_all(wasm_bytes) {
+        let payload = payload.expect("parse wasm");
+        if let wasmparser::Payload::ImportSection(reader) = payload {
+            for imp in reader {
+                let imp = imp.expect("parse import");
+                imports.push((imp.module.to_string(), imp.name.to_string()));
+            }
+        }
+    }
+    imports
+}
+
+/// **Test 1 — Bug A guard.** Build the fixture and assert that no
+/// import comes from `env` or `wasi_snapshot_preview1`. If this fails
+/// the failure message tells you exactly which shim to add.
+#[test]
+fn wasm_fixture_has_no_libc_imports() {
+    let wasm_path = build_fixture(/*release=*/ true);
+    let bytes = std::fs::read(&wasm_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", wasm_path.display()));
+    let imports = collect_imports(&bytes);
+
+    let mut offenders = Vec::new();
+    for (module, name) in &imports {
+        match module.as_str() {
+            "env" if !ALLOWED_ENV_IMPORTS.contains(&name.as_str()) => {
+                offenders.push(format!("env.{name}"));
+            }
+            "wasi_snapshot_preview1" if !ALLOWED_WASI_IMPORTS.contains(&name.as_str()) => {
+                offenders.push(format!("wasi_snapshot_preview1.{name}"));
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "fixture cdylib has {} disallowed wasm import(s). Add a pure-Rust \
+         shim to `src/wasm_runtime_shims.rs` (or `src/wasm_cxa_stubs.rs` \
+         for C++ ABI symbols) for each of the following, or update the \
+         ALLOWED_* lists in tests/wasm_smoke_test.rs if the symbol is \
+         a legitimate wasm-bindgen glue import:\n  {}\n\n\
+         Diagnostic: run\n    \
+         wasm-objdump -j Import -x {}",
+        offenders.len(),
+        offenders.join("\n  "),
+        wasm_path.display(),
+    );
+}
+
+/// Return true if `bin` exists on `PATH`.
+fn has_tool(bin: &str) -> bool {
+    Command::new(bin)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// **Test 2 — Bug B guard.** Build the fixture with `wasm-pack` (which
+/// invokes `wasm-bindgen` under the hood), then call the exported
+/// function many times from Node. A `command_export` trap fires on
+/// every call, so 100 iterations is plenty to catch it — but a single
+/// call is also enough in practice.
+///
+/// Skipped (with a `println!` diagnostic) if `wasm-pack` or `node`
+/// isn't on PATH. Test 1 already covers the root cause; this one is
+/// belt-and-suspenders for future wasm-bindgen regressions.
+#[test]
+fn wasm_fixture_instantiates_and_runs() {
+    if !has_tool("wasm-pack") {
+        eprintln!(
+            "SKIP wasm_fixture_instantiates_and_runs: `wasm-pack` not found on PATH. \
+             Install it with `cargo install wasm-pack` to run this test."
+        );
+        return;
+    }
+    if !has_tool("node") {
+        eprintln!(
+            "SKIP wasm_fixture_instantiates_and_runs: `node` not found on PATH. \
+             Install Node.js 20+ to run this test."
+        );
+        return;
+    }
+    require_wasm_target();
+
+    // Build with wasm-pack targeting nodejs. Use an isolated out-dir
+    // inside the fixture's own target/ so nested runs don't collide.
+    let fixture = fixture_dir();
+    let out_dir = fixture.join("target").join("wasm-pack-nodejs");
+    // Best effort cleanup of stale artifacts — ignore failures.
+    let _ = std::fs::remove_dir_all(&out_dir);
+
+    let status = Command::new("wasm-pack")
+        .args(["build", "--target", "nodejs", "--dev", "--out-dir"])
+        .arg(&out_dir)
+        .current_dir(&fixture)
+        .env_remove("RUSTFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .status()
+        .expect("spawn wasm-pack");
+    assert!(status.success(), "wasm-pack build failed");
+
+    // wasm-pack writes `<crate_name>.js` as the nodejs entry point.
+    // The fixture crate is named `blast-wasm-smoke-fixture`, which
+    // wasm-pack mangles to `blast_wasm_smoke_fixture`.
+    let entry = out_dir.join("blast_wasm_smoke_fixture.js");
+    assert!(
+        entry.exists(),
+        "wasm-pack produced no nodejs entry at {}",
+        entry.display()
+    );
+
+    // Drive the `blast_wasm_smoke` export from Node. The fixture
+    // annotates it with `#[wasm_bindgen]` so wasm-pack's generated
+    // `.js` wrapper re-exports it as a top-level function. Calling
+    // *any* wasm-bindgen wrapper is what trips Bug B: wasm-bindgen
+    // wraps each export with a `__wasm_call_dtors` post-call, which
+    // walks an uninitialised atexit table as soon as wasi imports
+    // are present.
+    let entry_literal = entry.to_string_lossy().replace('\\', "\\\\");
+    let driver = format!(
+        "const pkg = require('{entry_literal}');\n\
+         if (typeof pkg.blast_wasm_smoke !== 'function') {{\n\
+             console.error('no blast_wasm_smoke export; pkg keys:', Object.keys(pkg));\n\
+             process.exit(2);\n\
+         }}\n\
+         // First call — most likely to hit any startup trap.\n\
+         const first = pkg.blast_wasm_smoke();\n\
+         if (!(first >= 0)) {{ console.error('first call returned', first); process.exit(3); }}\n\
+         // Hammer it. Bug B fires on every call once wasi imports\n\
+         // are present, so a modest loop is enough.\n\
+         for (let i = 0; i < 100; i++) {{ pkg.blast_wasm_smoke(); }}\n\
+         console.log('ok', first);\n"
+    );
+
+    let out = Command::new("node")
+        .args(["-e", &driver])
+        .output()
+        .expect("spawn node");
+    assert!(
+        out.status.success(),
+        "node driver failed (exit {:?})\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+

--- a/blast/blast-stress-solver-rs/tests/wasm_smoke_test.rs
+++ b/blast/blast-stress-solver-rs/tests/wasm_smoke_test.rs
@@ -92,13 +92,21 @@ fn require_wasm_target() {
     // let `cargo build` produce its own error.
 }
 
-/// Build the fixture cdylib for `wasm32-unknown-unknown` and return
-/// the path to the produced `.wasm`.
+/// Build the fixture cdylib for `wasm32-unknown-unknown` in debug
+/// mode and return the path to the produced `.wasm`.
 ///
-/// We deliberately use an isolated `CARGO_TARGET_DIR` so the fixture
-/// build doesn't contend with the outer test run's target dir and
-/// nested cargo invocations never see each other's lockfiles.
-fn build_fixture(release: bool) -> PathBuf {
+/// **Why debug, not release?** Release-mode LTO + dead-code-elimination
+/// aggressively strips unused libc symbols. An early version of this
+/// test built `--release` and happily reported zero `env.*` imports
+/// while the actual wasm-pack `--dev` output — which is what
+/// downstream consumers ship in development — still imported
+/// `env.fputc` and `env.aligned_alloc`. Debug builds keep those
+/// symbols live, so they're what we want to assert against.
+///
+/// We also use an isolated `CARGO_TARGET_DIR` so the fixture build
+/// doesn't contend with the outer test run's target dir and nested
+/// cargo invocations never see each other's lockfiles.
+fn build_fixture() -> PathBuf {
     require_wasm_target();
 
     let fixture = fixture_dir();
@@ -114,9 +122,6 @@ fn build_fixture(release: bool) -> PathBuf {
     ])
     .arg(&manifest_path)
     .env("CARGO_TARGET_DIR", &target_dir);
-    if release {
-        cmd.arg("--release");
-    }
 
     // Strip any `RUSTFLAGS` the outer test run might have set — they
     // can inject native-target flags that break the wasm build.
@@ -131,10 +136,9 @@ fn build_fixture(release: bool) -> PathBuf {
         "failed to build the wasm smoke fixture cdylib — see cargo output above"
     );
 
-    let profile = if release { "release" } else { "debug" };
     let wasm = target_dir
         .join("wasm32-unknown-unknown")
-        .join(profile)
+        .join("debug")
         .join("blast_wasm_smoke_fixture.wasm");
     assert!(
         wasm.exists(),
@@ -164,7 +168,7 @@ fn collect_imports(wasm_bytes: &[u8]) -> Vec<(String, String)> {
 /// the failure message tells you exactly which shim to add.
 #[test]
 fn wasm_fixture_has_no_libc_imports() {
-    let wasm_path = build_fixture(/*release=*/ true);
+    let wasm_path = build_fixture();
     let bytes = std::fs::read(&wasm_path)
         .unwrap_or_else(|e| panic!("read {}: {e}", wasm_path.display()));
     let imports = collect_imports(&bytes);

--- a/blast/blast-stress-solver/src/rapier/destructible-core.ts
+++ b/blast/blast-stress-solver/src/rapier/destructible-core.ts
@@ -1174,17 +1174,41 @@ export async function buildDestructibleCore({
   function flushPendingBodies() {
     const t0 = startTiming();
 
-    // ── Fracture policy: body creation budget ──
-    // Prioritize largest children (most visually important), defer the rest.
-    const maxBodies = fracturePolicySettings.maxNewBodiesPerFrame;
-    if (maxBodies > 0 && pendingBodiesToCreate.length > maxBodies) {
+    // ── Fracture policy: body creation budgets ──
+    // Two caps can limit how many bodies we actually create this
+    // frame: `maxNewBodiesPerFrame` (per-frame budget) and
+    // `maxDynamicBodies` (global cap on total bodies in the world).
+    // When either binds, prioritize the largest children (most
+    // visually important) and defer the rest to a later frame —
+    // they stay in `pendingBodiesToCreate` and are reconsidered next
+    // frame after debris cleanup may have freed room.
+    //
+    // The global cap has to be enforced here at body-creation time,
+    // *not* upstream at fracture-command time: a single fracture
+    // step can generate dozens of pending bodies in one batch (e.g.
+    // a tower-collapse event), and the upstream "if count >= cap,
+    // drop commands" gate only fires *before* those bodies exist,
+    // so it can't catch "one frame of fracturing that blows past
+    // the cap". Here we break the loop mid-drain as soon as the
+    // running count hits the cap.
+    const maxPerFrame = fracturePolicySettings.maxNewBodiesPerFrame;
+    const maxTotal = fracturePolicySettings.maxDynamicBodies;
+    let runningTotal = maxTotal > 0 ? getRigidBodyCount() : 0;
+
+    const perFrameWouldBind =
+      maxPerFrame > 0 && pendingBodiesToCreate.length > maxPerFrame;
+    const totalWouldBind =
+      maxTotal > 0 && runningTotal + pendingBodiesToCreate.length > maxTotal;
+    if (perFrameWouldBind || totalWouldBind) {
       pendingBodiesToCreate.sort((a, b) => b.nodes.length - a.nodes.length);
     }
     let bodiesCreated = 0;
 
     for (const pending of pendingBodiesToCreate) {
-      // Enforce body creation budget — keep remaining entries for next frame
-      if (maxBodies > 0 && bodiesCreated >= maxBodies) break;
+      // Enforce per-frame new-body budget — keep remaining entries for next frame
+      if (maxPerFrame > 0 && bodiesCreated >= maxPerFrame) break;
+      // Enforce global dynamic-body cap — keep remaining entries for next frame
+      if (maxTotal > 0 && runningTotal >= maxTotal) break;
       const { actorIndex, inheritFromBodyHandle, nodes: nodeList, isSupport } = pending;
 
       const parentBody = world.getRigidBody(inheritFromBodyHandle);
@@ -1243,9 +1267,13 @@ export async function buildDestructibleCore({
         pendingColliderMigrations.push({ nodeIndex: ni, targetBodyHandle: bodyHandle });
       }
       bodiesCreated++;
+      runningTotal++;
     }
-    // Remove processed entries, keep deferred ones for next frame
-    if (maxBodies > 0 && bodiesCreated < pendingBodiesToCreate.length) {
+    // Remove processed entries, keep deferred ones for next frame.
+    // Either cap (per-frame or global) can cause an early break, so
+    // the check is "did we fully drain the queue?", not "was a
+    // specific cap set?".
+    if (bodiesCreated < pendingBodiesToCreate.length) {
       pendingBodiesToCreate.splice(0, bodiesCreated);
     } else {
       pendingBodiesToCreate.length = 0;

--- a/blast/include/shared/NvFoundation/NvPreprocessor.h
+++ b/blast/include/shared/NvFoundation/NvPreprocessor.h
@@ -96,6 +96,12 @@ Operating system defines, see http://sourceforge.net/p/predef/wiki/OperatingSyst
 #define NV_PSP2 1
 #elif defined(__ghs__)
 #define NV_WIIU 1
+#elif defined(__wasm__) || defined(__wasi__) || defined(__EMSCRIPTEN__)
+// WebAssembly builds (wasm32-unknown-unknown, wasm32-wasi, emscripten).
+// We piggy-back on the Linux code paths for operating-system macros —
+// the stress solver only needs basic libc and does not touch
+// OS-specific APIs, so Linux semantics are a safe match.
+#define NV_LINUX 1
 #else
 #error "Unknown operating system"
 #endif
@@ -115,6 +121,12 @@ Architecture defines, see http://sourceforge.net/p/predef/wiki/Architectures/
 #define NV_SPU 1
 #elif defined(__ppc__) || defined(_M_PPC) || defined(__CELLOS_LV2__)
 #define NV_PPC 1
+#elif defined(__wasm32__) || defined(__wasm__)
+// WebAssembly 32-bit linear memory. No native SIMD (the build passes
+// STRESS_SOLVER_FORCE_SCALAR so the solver never takes the SSE2/NEON path),
+// so we declare a new NV_WASM architecture and leave the SIMD macros as
+// zero (handled by the `#ifndef` fallbacks further down).
+#define NV_WASM 1
 #else
 #error "Unknown architecture"
 #endif
@@ -206,6 +218,9 @@ define anything not defined on this platform to 0
 #endif
 #ifndef NV_PPC
 #define NV_PPC 0
+#endif
+#ifndef NV_WASM
+#define NV_WASM 0
 #endif
 #ifndef NV_SSE2
 #define NV_SSE2 0

--- a/blast/source/sdk/globals/NvBlastGlobals.cpp
+++ b/blast/source/sdk/globals/NvBlastGlobals.cpp
@@ -59,7 +59,7 @@ NV_FORCE_INLINE void platformAlignedFree(void* ptr)
 {
     _aligned_free(ptr);
 }
-#elif NV_LINUX_FAMILY
+#elif NV_LINUX_FAMILY && !defined(__wasm__)
 NV_FORCE_INLINE void* platformAlignedAlloc(size_t size)
 {
     return ::memalign(16, size);

--- a/blast/source/shared/NsFoundation/include/NsArray.h
+++ b/blast/source/shared/NsFoundation/include/NsArray.h
@@ -32,7 +32,10 @@
 #include "NsBasicTemplates.h"
 #include "NvIntrinsics.h"
 
-#if defined(__EMSCRIPTEN__)
+#if defined(__EMSCRIPTEN__) || defined(__wasm__) || NV_WASM
+// WebAssembly builds — libc++ dropped the `tr1/type_traits` shim a long
+// time ago, so pull in modern `<type_traits>` and alias `is_pod` into the
+// `std::tr1` namespace for the rest of this TU.
 #include <type_traits>
 namespace std
 {


### PR DESCRIPTION
Provide pure-Rust stubs for every libc symbol the Blast C++ backend references (malloc/free/realloc, abort, strcmp/memchr/wcslen/wmemchr, stdio, locale, strto*, multibyte/wide-char, strftime_l, __cxa_atexit) plus trap-only __cxa_allocate_exception / __cxa_throw stubs. Drops the wasi-libc link, so the final cdylib has zero wasi_snapshot_preview1 imports and wasm-bindgen emits a normal library module instead of wrapping every export in a __wasm_call_dtors command_export shim.

Also add NV_WASM architecture + Linux-family OS mapping to NvPreprocessor.h, fall through the generic aligned-alloc path for __wasm__ in NvBlastGlobals.cpp, and include modern <type_traits> for __wasm__ / NV_WASM in NsArray.h.

<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->
